### PR TITLE
chore(tooling): fix publish script

### DIFF
--- a/scripts/utils/publish.js
+++ b/scripts/utils/publish.js
@@ -10,6 +10,6 @@ function npmPublishPackage(pkgName) {
   });
 }
 
-export default {
+module.exports = {
   npmPublishPackage
 };


### PR DESCRIPTION
Changed the script to module exports to match the rest of the scripts. When it was being required, it wasn't looking at the `default` object.