### PR TITLE
Fix NPM publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,7 +197,10 @@ ansiColor('xterm') {
                 string(credentialsId: 'NPM_TOKEN', variable: 'NPM_TOKEN')
               ]) {
                 try {
-                  sh 'echo \'//registry.npmjs.org/:_authToken=${NPM_TOKEN}\' >> .npmrc'
+                  // Back up .npmrc
+                  sh '[[ -f $HOME/.npmrc ]] && mv $HOME/.npmrc $HOME/.npmrc.bak'
+                  // Publish
+                  sh 'echo \'//registry.npmjs.org/:_authToken=${NPM_TOKEN}\' > $HOME/.npmrc'
                   echo ''
                   echo 'Reminder: E403 errors below are normal. They occur for any package that has no updates to publish'
                   echo ''
@@ -205,8 +208,9 @@ ansiColor('xterm') {
                   source ~/.nvm/nvm.sh
                   nvm use v8.9.1
                   npm run publish:components
-                  git checkout .npmrc
                   '''
+                  // Restore .npmrc
+                  sh '[[ -f $HOME/.npmrc.bak ]] && mv $HOME/.npmrc.bak $HOME/.npmrc'
                 }
                 catch (error) {
                   warn("failed to publish to npm ${error.toString()}")


### PR DESCRIPTION
- Fix NPM publishing
- Backup and restore existing .npmrc file in the shared slave $HOME directory