### PR TITLE
Fix NPM publish: add warn method

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,16 @@ def cleanup = { ->
   }
 }
 
+def warn = { msg ->
+  if (!currentBuild.description) {
+    currentBuild.description += ''
+  }
+  else if (currentBuild.description.substring(currentBuild.description.length() - 1) != '\n') {
+    currentBuild.description += '<br />\n'
+  }
+  currentBuild.description += "warning: ${msg}<br />\n"
+}
+
 ansiColor('xterm') {
   timestamps {
     timeout(90) {


### PR DESCRIPTION
- Add `warn` method that was not present (caused Jenkins failure). 
- I expect there will be more work after this because we're still getting into a warning state, but hopefully the printed error message will offer another clue. 