### PR TITLE
refactor(react-component): converts PropTypes.object to PropTypes.shape

### DIFF
--- a/packages/node_modules/@ciscospark/react-component-activity-item/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-item/src/index.js
@@ -16,7 +16,14 @@ const propTypes = {
     content: PropTypes.string,
     displayName: PropTypes.string,
     files: PropTypes.shape({
-      items: PropTypes.array
+      items: PropTypes.arrayOf(PropTypes.shape({
+        image: PropTypes.shape({
+          url: PropTypes.string
+        }),
+        thumbnail: PropTypes.string,
+        mimeType: PropTypes.string,
+        url: PropTypes.string
+      }))
     })
   }).isRequired,
   verb: PropTypes.string.isRequired

--- a/packages/node_modules/@ciscospark/react-component-activity-list/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-list/src/index.js
@@ -20,10 +20,17 @@ const propTypes = {
         content: PropTypes.string,
         displayName: PropTypes.string,
         files: PropTypes.shape({
-          items: PropTypes.array
+          items: PropTypes.arrayOf(PropTypes.shape({
+            image: PropTypes.shape({
+              url: PropTypes.string
+            }),
+            thumbnail: PropTypes.string,
+            mimeType: PropTypes.string,
+            url: PropTypes.string
+          }))
         })
-      }).isRequired,
-      actor: PropTypes.object,
+      }),
+      actor: PropTypes.object, // Are we even using it?
       published: PropTypes.string,
       verb: PropTypes.string
     }),

--- a/packages/node_modules/@ciscospark/react-component-activity-list/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-list/src/index.js
@@ -16,7 +16,13 @@ const propTypes = {
   activities: PropTypes.arrayOf(PropTypes.shape({
     activity: PropTypes.shape({
       id: PropTypes.string,
-      object: PropTypes.object,
+      object: PropTypes.shape({
+        content: PropTypes.string,
+        displayName: PropTypes.string,
+        files: PropTypes.shape({
+          items: PropTypes.array
+        })
+      }).isRequired,
       actor: PropTypes.object,
       published: PropTypes.string,
       verb: PropTypes.string

--- a/packages/node_modules/@ciscospark/react-component-activity-share-file/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-share-file/src/index.js
@@ -8,7 +8,11 @@ import {bytesToSize} from '@ciscospark/react-component-utils';
 import styles from './styles.css';
 
 const propTypes = {
-  file: PropTypes.object.isRequired,
+  file: PropTypes.shape({
+    displayName: PropTypes.string,
+    fileSize: PropTypes.number,
+    objectType: PropTypes.string
+  }).isRequired,
   isPending: PropTypes.bool,
   onDownloadClick: PropTypes.func.isRequired
 };

--- a/packages/node_modules/@ciscospark/react-component-activity-share-files/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-share-files/src/index.js
@@ -11,7 +11,14 @@ import styles from './styles.css';
 const propTypes = {
   content: PropTypes.string,
   displayName: PropTypes.string,
-  files: PropTypes.array.isRequired,
+  files: PropTypes.arrayOf(PropTypes.shape({
+    image: PropTypes.shape({
+      url: PropTypes.string
+    }),
+    thumbnail: PropTypes.string,
+    mimeType: PropTypes.string,
+    url: PropTypes.string
+  })).isRequired,
   isPending: PropTypes.bool,
   onDownloadClick: PropTypes.func.isRequired,
   share: PropTypes.object.isRequired

--- a/packages/node_modules/@ciscospark/react-component-activity-share-thumbnail/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-share-thumbnail/src/index.js
@@ -9,7 +9,11 @@ import {bytesToSize} from '@ciscospark/react-component-utils';
 import styles from './styles.css';
 
 const propTypes = {
-  file: PropTypes.object.isRequired,
+  file: PropTypes.shape({
+    displayName: PropTypes.string,
+    fileSize: PropTypes.number,
+    objectType: PropTypes.string
+  }).isRequired,
   isFetching: PropTypes.bool,
   isPending: PropTypes.bool,
   objectUrl: PropTypes.string,

--- a/packages/node_modules/@ciscospark/react-component-activity-system-message/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-system-message/src/index.js
@@ -25,9 +25,25 @@ export const SYSTEM_MESSAGE_VERBS = [
 ];
 
 const propTypes = {
-  activity: PropTypes.object,
-  actor: PropTypes.object,
-  currentUser: PropTypes.object,
+  activity: PropTypes.shape({
+    duration: PropTypes.number.isRequired,
+    isGroupCall: PropTypes.bool.isRequired,
+    participants: PropTypes.arrayOf(
+      PropTypes.shape({
+        isInitiator: PropTypes.bool,
+        person: PropTypes.shape({
+          entryUUID: PropTypes.string
+        }),
+        state: PropTypes.string
+      })
+    )
+  }),
+  actor: PropTypes.shape({
+    entryUUID: PropTypes.string
+  }),
+  currentUser: PropTypes.shape({
+    id: PropTypes.string.isRequired
+  }),
   isSelf: PropTypes.bool,
   name: PropTypes.string.isRequired,
   timestamp: PropTypes.string,

--- a/packages/node_modules/@ciscospark/react-component-day-separator/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-day-separator/src/index.js
@@ -5,9 +5,9 @@ import ListSeparator from '@ciscospark/react-component-list-separator';
 import calculateDateText from './calculateDateText';
 
 const propTypes = {
-  fromDate: PropTypes.object.isRequired,
-  now: PropTypes.object.isRequired,
-  toDate: PropTypes.object.isRequired
+  fromDate: PropTypes.instanceOf(Date).isRequired,
+  now: PropTypes.instanceOf(Date).isRequired,
+  toDate: PropTypes.instanceOf(Date).isRequired
 };
 
 function DaySeparator({

--- a/packages/node_modules/@ciscospark/react-component-file-share-display/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-file-share-display/src/index.js
@@ -10,7 +10,11 @@ const defaultProps = {
 };
 
 const propTypes = {
-  file: PropTypes.object.isRequired,
+  file: PropTypes.shape({
+    displayName: PropTypes.string,
+    fileSize: PropTypes.number,
+    objectType: PropTypes.string
+  }).isRequired,
   isFetching: PropTypes.bool.isRequired,
   isPending: PropTypes.bool,
   objectUrl: PropTypes.string,

--- a/packages/node_modules/@ciscospark/react-component-file-staging-area/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-file-staging-area/src/index.js
@@ -8,7 +8,15 @@ import ChipFile from '@ciscospark/react-component-chip-file';
 import styles from './styles.css';
 
 const propTypes = {
-  files: PropTypes.object.isRequired,
+  files: PropTypes.shape({
+    items: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string,
+      type: PropTypes.string,
+      id: PropTypes.string,
+      thumbnail: PropTypes.string,
+      fileSize: PropTypes.number
+    }))
+  }).isRequired,
   onFileRemove: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired
 };


### PR DESCRIPTION
converts PropTypes.object to PropTypes.shape under react-component-* folders only.