### PR TITLE
style(icon): use camel case for main

### DIFF
--- a/packages/node_modules/@ciscospark/react-component-icon/src/styles.css
+++ b/packages/node_modules/@ciscospark/react-component-icon/src/styles.css
@@ -1,15 +1,16 @@
 /* Imported from https://sqbu-github.cisco.com/WebExSquared/spark-icons */
 @font-face {
   font-family: 'Neo-icons';
-  src:  url('fonts/Neo-icons.woff?mujx6') format('woff');
+  src:
+    local('Neo-icons'),
+    url('./fonts/Neo-icons.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }
 
-.ciscospark-icon {
+.ciscosparkIcon {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'Neo-icons' !important;
-  speak: none;
   font-style: normal;
   font-weight: normal;
   font-variant: normal;


### PR DESCRIPTION
Still not 100% on font loading with webpack via create-react-app, but this is definitely needed to start.