### PR TITLE
feat(space-item): add active prop

### DIFF
--- a/packages/node_modules/@ciscospark/react-component-space-item/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@ciscospark/react-component-space-item/src/__snapshots__/index.test.js.snap
@@ -1,10 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SpaceItem component correctly renders an active space 1`] = `
+<div
+  className="space-item item active"
+  onKeyDown={[Function]}
+  onMouseDown={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  <div
+    className="space-avatar-wrapper avatarWrapper"
+  >
+    <div
+      className="space-avatar-border"
+    >
+      <Avatar
+        baseColor="blue"
+        image=""
+        isSelfAvatar={false}
+        name="Webex User"
+      />
+    </div>
+  </div>
+  <div
+    className="space-item-meta meta"
+  >
+    <div
+      className="space-team-name teamName"
+      style={
+        Object {
+          "color": "#f5f5f5",
+        }
+      }
+    >
+      Best Team
+    </div>
+    <div
+      className="space-title title"
+    >
+      Webex User
+    </div>
+    <div
+      className="space-last-activity lastActivity"
+    >
+      I'm active!
+    </div>
+  </div>
+  <div
+    className="space-last-activity-time timestamp"
+  >
+    3:05 PM
+  </div>
+</div>
+`;
+
 exports[`SpaceItem component renders a decrypting space 1`] = `
 <div
   className="space-item item isDecrypting"
-  onClick={[Function]}
   onKeyDown={[Function]}
+  onMouseDown={[Function]}
   role="button"
   tabIndex="0"
 >
@@ -48,8 +102,8 @@ exports[`SpaceItem component renders a decrypting space 1`] = `
 exports[`SpaceItem component renders a space 1`] = `
 <div
   className="space-item item hasCallSupport"
-  onClick={[Function]}
   onKeyDown={[Function]}
+  onMouseDown={[Function]}
   role="button"
   tabIndex="0"
 >
@@ -118,8 +172,8 @@ exports[`SpaceItem component renders a space 1`] = `
 exports[`SpaceItem component renders a space with a call in progress 1`] = `
 <div
   className="space-item item hasCallSupport"
-  onClick={[Function]}
   onKeyDown={[Function]}
+  onMouseDown={[Function]}
   role="button"
   tabIndex="0"
 >
@@ -178,8 +232,8 @@ exports[`SpaceItem component renders a space with a call in progress 1`] = `
 exports[`SpaceItem component renders a space with a call in progress without call support 1`] = `
 <div
   className="space-item item"
-  onClick={[Function]}
   onKeyDown={[Function]}
+  onMouseDown={[Function]}
   role="button"
   tabIndex="0"
 >

--- a/packages/node_modules/@ciscospark/react-component-space-item/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-space-item/src/index.js
@@ -11,6 +11,7 @@ import styles from './styles.css';
 
 
 const propTypes = {
+  active: PropTypes.bool,
   avatarUrl: PropTypes.string,
   activityText: PropTypes.oneOfType([
     PropTypes.string,
@@ -31,6 +32,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  active: false,
   activityText: '',
   avatarUrl: '',
   callStartTime: undefined,
@@ -48,6 +50,7 @@ const defaultProps = {
 };
 
 function SpaceItem({
+  active,
   activityText,
   avatarUrl,
   callStartTime,
@@ -91,10 +94,11 @@ function SpaceItem({
     <div
       className={classNames('space-item', styles.item, {
         [styles.hasCallSupport]: !!hasCallSupport,
-        [styles.isDecrypting]: !!isDecrypting
+        [styles.isDecrypting]: !!isDecrypting,
+        [styles.active]: !!active
       })}
-      onClick={handleClick}
       onKeyDown={handleKeyDown}
+      onMouseDown={handleClick}
       role="button"
       tabIndex="0"
     >
@@ -112,7 +116,7 @@ function SpaceItem({
           teamName &&
           <div
             className={classNames('space-team-name', styles.teamName)}
-            style={teamColor && {color: teamColor}}
+            style={active ? {color: '#f5f5f5'} : teamColor && {color: teamColor}}
           >
             {teamName}
           </div>

--- a/packages/node_modules/@ciscospark/react-component-space-item/src/index.test.js
+++ b/packages/node_modules/@ciscospark/react-component-space-item/src/index.test.js
@@ -44,6 +44,28 @@ describe('SpaceItem component', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('correctly renders an active space', () => {
+    renderer.render(
+      <SpaceItem
+        activityText="I'm active!"
+        id="active-space-id"
+        lastActivityTime="3:05 PM"
+        latestActivity={{
+          actorName: 'Andrew',
+          type: 'post'
+        }}
+        active
+        onCallClick={onClick}
+        onClick={onClick}
+        name="Webex User"
+        teamColor="blue"
+        teamName="Best Team"
+      />
+    );
+    const component = renderer.getRenderOutput();
+    expect(component).toMatchSnapshot();
+  });
+
   it('renders a space with a call in progress', () => {
     renderer.render(
       <SpaceItem

--- a/packages/node_modules/@ciscospark/react-component-space-item/src/styles.css
+++ b/packages/node_modules/@ciscospark/react-component-space-item/src/styles.css
@@ -6,8 +6,17 @@
   outline: none;
 }
 
+.item.active {
+  background-color: #07c1e4;
+  color: #f5f5f5;
+}
+
 .item:hover {
   background: #efefef;
+}
+
+.item.active:hover {
+  background-color: #07c1e4;
 }
 
 .actions {
@@ -83,6 +92,10 @@
   white-space: nowrap;
 }
 
+.active .title {
+  color: #f5f5f5;
+}
+
 .title.isUnread {
   font-weight: 300;
 }
@@ -103,10 +116,18 @@
   white-space: nowrap;
 }
 
+.active .lastActivity {
+  color: #f5f5f5;
+}
+
 .timestamp {
   font-size: 10px;
   color: #999;
   white-space: nowrap;
+}
+
+.active .timestamp {
+  color: #f5f5f5;
 }
 
 .hasCallSupport:hover .timestamp {

--- a/packages/node_modules/@ciscospark/react-component-spaces-list/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-spaces-list/src/index.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import SpaceItem from '@ciscospark/react-component-space-item';
 
 const propTypes = {
+  activeSpaceId: PropTypes.string,
   currentUser: PropTypes.shape({
     id: PropTypes.string.isRequired
   }).isRequired,
@@ -36,6 +37,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  activeSpaceId: '',
   hasCalling: false,
   onCallClick: () => {},
   onClick: () => {},
@@ -43,6 +45,7 @@ const defaultProps = {
 };
 
 export default function SpacesList({
+  activeSpaceId,
   currentUser,
   hasCalling,
   onCallClick,
@@ -51,6 +54,7 @@ export default function SpacesList({
 }) {
   const recents = [];
   spaces.forEach((space) => recents.push(<SpaceItem
+    active={space.id === activeSpaceId}
     currentUser={currentUser}
     hasCalling={hasCalling}
     key={space.id}

--- a/samples/recents-components/index.js
+++ b/samples/recents-components/index.js
@@ -99,6 +99,23 @@ function RecentsComponents() {
         teamColor="blue"
         teamName="Best Team"
       />
+      <SpaceItem
+        activityText="I'm an active space!"
+        currentUser={currentUser}
+        formatMessage={(a) => a}
+        id="active-space-id"
+        lastActivityTime="8:02 AM"
+        latestActivity={{
+          actorName: 'Andrew',
+          type: 'post'
+        }}
+        active
+        onCallClick={onCallClick}
+        onClick={onClick}
+        name="Webex Teams"
+        teamColor="green"
+        teamName="Web Team"
+      />
       <h3>SpaceList</h3>
       <SpacesList
         currentUser={currentUser}


### PR DESCRIPTION
This adds an activeSpaceId prop to the `react-component-spaces-list` and `react-component-space-item`. The idea being you pass it into the list itself and each space item checks if it's "active" or not. When it is, it adds an `.active` class to the component. 

Question:

I've never really used snapshots before. I wanted to explicitly assert that the `active` class was added to the component (since the first time my snapshot rendered, it wasn't). Is there a better way to do that?

Todo: Add tests for the spaces-list component? There's none presently. 