### PR TITLE
 fix(r-c-read-receipts): add support for empty activities

### DIFF
--- a/packages/node_modules/@ciscospark/react-container-read-receipts/src/selectors.js
+++ b/packages/node_modules/@ciscospark/react-container-read-receipts/src/selectors.js
@@ -19,7 +19,7 @@ const getReadReceipts = createSelector(
     const activity = activities.last();
     const readParticipants = participants
       .filter((participant) =>
-        participant.get('id') !== currentUser.id &&
+        activity && currentUser && participant.get('id') !== currentUser.id &&
         participant.getIn(['roomProperties', 'lastSeenActivityUUID']) === activity.id)
       .toJS();
 

--- a/scripts/webpack/webpack.dev.babel.js
+++ b/scripts/webpack/webpack.dev.babel.js
@@ -32,7 +32,7 @@ export default webpackConfigBase({
   devtool: 'source-map',
   devServer: {
     host: '0.0.0.0',
-    port: 8000,
+    port: process.env.PORT || 8000,
     stats: {
       colors: true,
       hash: false,


### PR DESCRIPTION
If the read receipt component rendered before activities loaded a js error would throw on undefined.