### PR TITLE
feat(widget-space-demo): add option to disable default activities

### DIFF
--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
@@ -11,6 +11,7 @@ import AppBar from 'material-ui/AppBar';
 import Toggle from 'material-ui/Toggle';
 import {RadioButtonGroup, RadioButton} from 'material-ui/RadioButton';
 import {Card, CardActions, CardTitle, CardText} from 'material-ui/Card';
+import Checkbox from 'material-ui/Checkbox';
 
 import SyntaxHighlighter from 'react-syntax-highlighter/prism';
 import {coy} from 'react-syntax-highlighter/styles/prism';
@@ -39,6 +40,12 @@ class DemoWidgetSpace extends Component {
     }
     this.state = {
       accessToken: cookies.get('accessToken') || '',
+      activities: {
+        files: true,
+        meet: true,
+        message: true,
+        people: true
+      },
       displayToken: false,
       mode,
       running: false,
@@ -71,6 +78,7 @@ class DemoWidgetSpace extends Component {
         onEvent: (eventName, detail) => {
           window.ciscoSparkEvents.push({eventName, detail});
         },
+        spaceActivities: this.state.activities,
         toPersonEmail: toPerson
       });
     }
@@ -80,6 +88,7 @@ class DemoWidgetSpace extends Component {
         onEvent: (eventName, detail) => {
           window.ciscoSparkEvents.push({eventName, detail});
         },
+        spaceActivities: this.state.activities,
         spaceId: toSpace
       });
     }
@@ -111,6 +120,13 @@ class DemoWidgetSpace extends Component {
   @autobind
   handleModeChange(e, value) {
     return this.setState({mode: value});
+  }
+
+  @autobind
+  handleActivitiesChange(event, isInputChecked) {
+    const {activities} = this.state;
+    activities[event.target.value] = isInputChecked;
+    return this.setState({activities});
   }
 
   @autobind
@@ -195,6 +211,7 @@ class DemoWidgetSpace extends Component {
               title="Choose Widget Destination"
             />
             <CardText expandable>
+              <h3> Widget Destination Type </h3>
               <div className={classNames(styles.select)}>
                 <RadioButtonGroup
                   aria-label="Widget 'To' Type"
@@ -214,32 +231,62 @@ class DemoWidgetSpace extends Component {
                   />
                 </RadioButtonGroup>
               </div>
-              {
-                this.state.mode === MODE_SPACE &&
-                <div>
-                  <input
-                    aria-label="To Space ID"
-                    className={styles.textInput}
-                    id="toSpaceId"
-                    onChange={this.handleSpaceChange}
-                    placeholder="Spark Space Id"
-                    value={this.state.spaceId}
-                  />
-                </div>
-              }
-              {
-                this.state.mode === MODE_ONE_ON_ONE &&
-                <div>
-                  <input
-                    aria-label="To User Email"
-                    className={styles.textInput}
-                    id="toUserEmail"
-                    onChange={this.handleEmailChange}
-                    placeholder="Spark User Email (For 1:1)"
-                    value={this.state.toPersonEmail}
-                  />
-                </div>
-              }
+
+              <div>
+                <h3> Widget Activities </h3>
+                <Checkbox
+                  checked={this.state.activities.files}
+                  label="Files"
+                  onCheck={this.handleActivitiesChange}
+                  value="files"
+                />
+                <Checkbox
+                  checked={this.state.activities.meet}
+                  label="Meet"
+                  onCheck={this.handleActivitiesChange}
+                  value="meet"
+                />
+                <Checkbox
+                  checked={this.state.activities.message}
+                  label="Message"
+                  onCheck={this.handleActivitiesChange}
+                  value="message"
+                />
+                <Checkbox
+                  checked={this.state.activities.people}
+                  label="People"
+                  onCheck={this.handleActivitiesChange}
+                  value="people"
+                />
+              </div>
+              <div>
+                {
+                  this.state.mode === MODE_SPACE &&
+                  <div>
+                    <input
+                      aria-label="To Space ID"
+                      className={styles.textInput}
+                      id="toSpaceId"
+                      onChange={this.handleSpaceChange}
+                      placeholder="Spark Space Id"
+                      value={this.state.spaceId}
+                    />
+                  </div>
+                }
+                {
+                  this.state.mode === MODE_ONE_ON_ONE &&
+                  <div>
+                    <input
+                      aria-label="To User Email"
+                      className={styles.textInput}
+                      id="toUserEmail"
+                      onChange={this.handleEmailChange}
+                      placeholder="Spark User Email (For 1:1)"
+                      value={this.state.toPersonEmail}
+                    />
+                  </div>
+                }
+              </div>
             </CardText>
             <CardActions expandable>
               <RaisedButton

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/errors.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/errors.js
@@ -94,7 +94,9 @@ function checkForErrors(props) {
   }
 
   const invalidActivityId = 'ciscospark.container.space.error.invalidActivity';
-  const validActivity = initialActivity ? activityTypes.some((activity) => activity.name === initialActivity) : true;
+  const defaultActivity = 'message';
+  const validActivity = initialActivity ? activityTypes.some((activity) => activity.name === initialActivity)
+    : activityTypes.some((activity) => activity.name === defaultActivity);
   if (!validActivity && !errors.get('errors').has(invalidActivityId)) {
     props.addError({
       id: invalidActivityId,

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -128,8 +128,7 @@ exports.config = {
       './test/journeys/specs/space/global/basic.js',
       './test/journeys/specs/space/global/meet.js',
       './test/journeys/specs/space/global/messaging.js',
-      './test/journeys/specs/space/global/startup-settings.js',
-      './test/journeys/specs/space/featureFlags.js'
+      './test/journeys/specs/space/global/startup-settings.js'
     ],
     recents: [
       './test/journeys/specs/recents/dataApi/basic.js',
@@ -159,8 +158,7 @@ exports.config = {
       './test/journeys/specs/space/global/basic.js',
       './test/journeys/specs/space/global/meet.js',
       './test/journeys/specs/space/global/messaging.js',
-      './test/journeys/specs/space/global/startup-settings.js',
-      './test/journeys/specs/space/featureFlags.js'
+      './test/journeys/specs/space/global/startup-settings.js'
     ],
     guest: [
       './test/journeys/specs/oneOnOne/dataApi/guest.js',


### PR DESCRIPTION
The demo for disabling activities was added to widget-demo, which is not available on the CDN. This PR will make those options appear on the CDN space widget demo. 