### PR TITLE
chore(tooling): use webpack env command line feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-react": "^7.5.1",
+    "execa": "^0.10.0",
     "extract-text-webpack-plugin": "^3.0.1",
     "file-loader": "^1.0.0",
     "html-webpack-plugin": "^2.30.1",

--- a/scripts/publish/commands/components.js
+++ b/scripts/publish/commands/components.js
@@ -9,13 +9,13 @@ module.exports = {
   desc: 'Publish all component and module packages',
   builder: {},
   handler: () =>
-    getAllPackagePaths().map((pkg) => {
+    getAllPackagePaths().map((pkgPath) => {
       try {
-        const pkgJson = require(path.resolve(pkg, 'package.json'));
+        const pkgJson = require(path.resolve(pkgPath, 'package.json'));
         const pkgName = pkgJson.name.split('/').pop();
         const isWidget = pkgName.startsWith('widget-');
         if (!isWidget && !pkgJson.private) {
-          return npmPublishPackage(pkgName);
+          return npmPublishPackage(pkgName, pkgPath);
         }
       }
       catch (err) {

--- a/scripts/start/commands/samples.js
+++ b/scripts/start/commands/samples.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const {execSync} = require('../../utils/exec');
+const {exec} = require('../../utils/exec');
 
 module.exports = {
   command: 'samples',
@@ -9,7 +9,7 @@ module.exports = {
   handler: () => {
     console.info('Starting the samples ...');
     const command = `webpack-dev-server --config scripts/webpack/webpack.dev.babel.js --hot --inline --history-api-fallback --context ${path.resolve('./samples')}`;
-    execSync(command)
+    exec(command)
       .catch((error) => {
         console.error(error.stdout);
         throw new Error('Error when running start samples', error);

--- a/scripts/utils/build.js
+++ b/scripts/utils/build.js
@@ -71,7 +71,7 @@ function webpackBuild(pkgName, pkgPath) {
       console.info(`Cleaning ${pkgName} dist folder...`.cyan);
       rimraf.sync(path.resolve(targetPkgPath, 'dist'));
       console.info(`Bundling ${pkgName}...`.cyan);
-      execSync(`cd ${targetPkgPath} && webpack --config ${webpackConfigPath}`);
+      execSync(`cd ${targetPkgPath} && webpack --config ${webpackConfigPath} --env.package=${pkgName}`);
       console.info(`${pkgName}... Done\n\n`.cyan);
     }
     catch (err) {

--- a/scripts/utils/exec.js
+++ b/scripts/utils/exec.js
@@ -2,7 +2,7 @@
  * Borrowed from React Bootstrap
  * https://github.com/react-bootstrap/react-bootstrap
  */
-const processExecSync = require('child_process').execSync;
+const {shellSync} = require('execa');
 
 const processExec = require('child-process-promise').exec;
 require('colors');
@@ -78,7 +78,7 @@ function setExecOptions(options) {
 }
 
 function execSync(command) {
-  return processExecSync(command, {stdio: 'inherit'});
+  return shellSync(command, {stdio: 'inherit'});
 }
 
 module.exports = {

--- a/scripts/utils/git.js
+++ b/scripts/utils/git.js
@@ -1,14 +1,14 @@
 /*!
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
-const {execSync} = require('child_process');
+const {shellSync} = require('execa');
 
 const debug = require('debug')('tooling:git');
 
 exports.diff = async function diff(tag) {
   debug(`diffing HEAD against ${tag}`);
   debug(`Shelling out to \`git diff --name-only HEAD..${tag}\``);
-  const raw = String(execSync(`git diff --name-only HEAD..${tag}`));
+  const raw = String(shellSync(`git diff --name-only HEAD..${tag}`));
 
   debug('Done');
 
@@ -22,7 +22,7 @@ exports.lastLog = function lastLog() {
   const treeLike = process.env.GIT_COMMIT || 'HEAD';
   const cmd = `git log -n 1 --format=%B ${treeLike}`;
   debug(`Shelling out to ${cmd}`);
-  const log = String(execSync(cmd));
+  const log = String(shellSync(cmd));
   debug('Done');
   return log;
 };

--- a/scripts/utils/package.js
+++ b/scripts/utils/package.js
@@ -90,16 +90,12 @@ function runInPackage({
   pkgName,
   pkgPath
 }) {
-  const outputPkgPath = getPackage(pkgName || pkgPath);
+  const outputPkgPath = getPackage(pkgPath || pkgName);
   if (outputPkgPath) {
     try {
       console.info(`${commandName} ${pkgName} ...`);
       const command = constructCommand(outputPkgPath);
-      execSync(command)
-        .catch((error) => {
-          console.error(error.stdout);
-          throw new Error(`Error when running ${commandName} on ${pkgName}`, error);
-        });
+      execSync(command);
     }
     catch (err) {
       throw new Error(`Error ${commandName} ${pkgName} package`, err);

--- a/scripts/utils/package.js
+++ b/scripts/utils/package.js
@@ -158,7 +158,7 @@ function getWidgetPackages() {
  */
 function startPackage(pkgName, pkgPath) {
   return runInPackage({
-    constructCommand: (targetPath) => `webpack-dev-server --config scripts/webpack/webpack.dev.babel.js --hot --inline --history-api-fallback --context ${path.resolve(targetPath, 'src')}`,
+    constructCommand: (targetPath) => `webpack-dev-server --config scripts/webpack/webpack.dev.babel.js --hot --inline --history-api-fallback --context ${path.resolve(targetPath, 'src')} --env.package=${pkgName}`,
     commandName: 'Start Package',
     pkgName,
     pkgPath

--- a/scripts/utils/publish.js
+++ b/scripts/utils/publish.js
@@ -2,11 +2,12 @@ const path = require('path');
 
 const {runInPackage} = require('./package');
 
-function npmPublishPackage(pkgName) {
+function npmPublishPackage(pkgName, pkgPath) {
   return runInPackage({
-    constructCommand: (targetPath) => `cd ${path.resolve(targetPath)} && npm publish --access public`,
+    constructCommand: (targetPath) => `cd ${path.resolve(targetPath)} && npm pack --access public`,
     commandName: 'Publish Package to NPM',
-    pkgName
+    pkgName,
+    pkgPath
   });
 }
 

--- a/scripts/webpack/webpack.base.babel.js
+++ b/scripts/webpack/webpack.base.babel.js
@@ -10,7 +10,7 @@ dotenv.config();
 
 process.env.REACT_CISCOSPARK_VERSION = version;
 
-export default (options) => {
+export default (options, env) => {
   const packageJson = require('../../package.json');
   const plugins = [
     new webpack.EnvironmentPlugin([
@@ -80,7 +80,7 @@ export default (options) => {
               options: {
                 camelCase: true,
                 modules: true,
-                localIdentName: '[local]--[hash:base64:5]',
+                localIdentName: `${env && env.package ? env.package : 'widget'}--[local]--[hash:base64:5]`,
                 importLoaders: 1,
                 sourceMap: true
               }

--- a/scripts/webpack/webpack.dev.babel.js
+++ b/scripts/webpack/webpack.dev.babel.js
@@ -26,7 +26,8 @@ const plugins = [
   ])
 ];
 
-export default webpackConfigBase({
+// env config object from command line: https://webpack.js.org/guides/environment-variables/
+export default (env) => webpackConfigBase({
   entry: './index.js',
   plugins,
   devtool: 'source-map',
@@ -53,4 +54,4 @@ export default webpackConfigBase({
       'Content-Security-Policy': 'script-src \'self\' \'unsafe-inline\' code.s4d.io; style-src \'self\' \'unsafe-inline\' code.s4d.io; media-src \'self\' code.s4d.io *.clouddrive.com data: blob:; font-src \'self\' code.s4d.io; img-src \'self\' code.s4d.io *.clouddrive.com data: blob: *.rackcdn.com; connect-src \'self\' localhost ws://localhost:8000 wss://*.wbx.com wss://*.wbx2.com ws://*.wbx.com *.wbx2.com *.webex.com code.s4d.io *.ciscospark.com https://*.clouddrive.com/;'
     }
   }
-});
+}, env);

--- a/scripts/webpack/webpack.prod.babel.js
+++ b/scripts/webpack/webpack.prod.babel.js
@@ -53,7 +53,8 @@ if (fs.existsSync('./src/index.html')) {
 
 const publicPath = process.env.BUILD_PUBLIC_PATH;
 
-export default webpackBaseConfig({
+// env config object from command line: https://webpack.js.org/guides/environment-variables/
+export default (env) => webpackBaseConfig({
   entry: './index.js',
   output: {
     filename: 'bundle.js',
@@ -70,4 +71,4 @@ export default webpackBaseConfig({
     TO_PERSON_EMAIL: '',
     TO_PERSON_ID: ''
   }
-});
+}, env);


### PR DESCRIPTION
Utilizes the [environment variable config](https://webpack.js.org/guides/environment-variables/) to provide a starting string for the css class name.

That way, if you run `npm build:package widget-space` it will name all css classes with `widget-space--[classname]--[hash]`.