### PR TITLE
chore: remove metrics from widgets for now

### DIFF
--- a/packages/node_modules/@ciscospark/react-redux-spark-fixtures/src/__fixtures__/spark.js
+++ b/packages/node_modules/@ciscospark/react-redux-spark-fixtures/src/__fixtures__/spark.js
@@ -70,12 +70,6 @@ export default function createSpark() {
         get: genMockFunction(),
         unassign: genMockFunction(),
         update: genMockFunction()
-      },
-
-      metrics: {
-        sendUnstructured: genMockFunction(),
-        sendSemiStructured: genMockFunction(),
-        submitClientMetrics: genMockFunction()
       }
     },
 

--- a/packages/node_modules/@ciscospark/react-redux-spark/src/component.js
+++ b/packages/node_modules/@ciscospark/react-redux-spark/src/component.js
@@ -10,21 +10,7 @@ import {
 } from './actions';
 import createSpark, {createSparkJwt} from './spark';
 
-const metricName = {
-  SPARK_AUTHENTICATED: {
-    resource: 'spark',
-    event: 'authentication',
-    action: 'authenticated'
-  },
-  DEVICE_REGISTERED: {
-    resource: 'device',
-    event: 'registration',
-    action: 'registered'
-  }
-};
-
 const injectedPropTypes = {
-  metrics: PropTypes.object.isRequired,
   spark: PropTypes.object.isRequired,
   storeSparkInstance: PropTypes.func.isRequired,
   updateSparkStatus: PropTypes.func.isRequired
@@ -43,11 +29,7 @@ const defaultProps = {
 
 class SparkComponent extends Component {
   static listenToSparkEvents(spark, props) {
-    const {metrics} = props;
     spark.listenToAndRun(spark, 'change:canAuthorize', () => {
-      if (metrics && spark.canAuthorize) {
-        metrics.sendElapsedTime(metricName.SPARK_AUTHENTICATED, spark);
-      }
       props.updateSparkStatus({authenticated: spark.canAuthorize});
     });
 
@@ -56,9 +38,6 @@ class SparkComponent extends Component {
     });
 
     spark.listenToAndRun(spark.internal.device, 'change:registered', () => {
-      if (metrics && spark.internal.device.registered) {
-        metrics.sendElapsedTime(metricName.DEVICE_REGISTERED, spark);
-      }
       props.updateSparkStatus({registered: spark.internal.device.registered});
     });
 

--- a/packages/node_modules/@ciscospark/react-redux-spark/src/spark.js
+++ b/packages/node_modules/@ciscospark/react-redux-spark/src/spark.js
@@ -4,7 +4,6 @@ import '@ciscospark/internal-plugin-mercury';
 import '@ciscospark/plugin-people';
 import '@ciscospark/internal-plugin-conversation';
 import '@ciscospark/plugin-phone';
-import '@ciscospark/internal-plugin-metrics';
 import '@ciscospark/internal-plugin-flag';
 import '@ciscospark/internal-plugin-feature';
 import '@ciscospark/internal-plugin-presence';

--- a/packages/node_modules/@ciscospark/spark-widget-base/src/enhancers/withInitialState.js
+++ b/packages/node_modules/@ciscospark/spark-widget-base/src/enhancers/withInitialState.js
@@ -11,7 +11,6 @@ import thunk from 'redux-thunk';
 import PropTypes from 'prop-types';
 import sparkReducer from '@ciscospark/react-redux-spark';
 import usersReducer from '@ciscospark/redux-module-users';
-import metricsReducer from '@ciscospark/react-redux-spark-metrics';
 
 import {REMOVE_WIDGET} from './withRemoveWidget';
 
@@ -20,7 +19,6 @@ function constructReducers(reducers) {
 
   rootReducers.spark = sparkReducer;
   rootReducers.users = usersReducer;
-  rootReducers.metricsStore = metricsReducer;
   const widgetReducer = combineReducers(rootReducers);
 
   return (state, action) => {

--- a/packages/node_modules/@ciscospark/spark-widget-base/src/index.js
+++ b/packages/node_modules/@ciscospark/spark-widget-base/src/index.js
@@ -5,7 +5,6 @@ import {
 } from 'recompose';
 
 import {withSpark} from '@ciscospark/react-redux-spark';
-import {withSparkMetrics} from '@ciscospark/react-redux-spark-metrics';
 import '@ciscospark/react-component-spark-fonts';
 
 import {
@@ -41,8 +40,6 @@ export function constructSparkEnhancer({
     withInitialState({reducers, enhancers}),
     // Clears store on Remove
     withRemoveWidget,
-    // Add Metrics mothods as props
-    withSparkMetrics(name),
     // Connects and Auths with Spark API
     withSpark,
     // Retrieves and stores current user

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -22,7 +22,6 @@ import {
 import {storeActivities} from '@ciscospark/redux-module-activities';
 import {fetchAvatar} from '@ciscospark/redux-module-avatar';
 import {fetchTeams} from '@ciscospark/redux-module-teams';
-import {events as metricEvents} from '@ciscospark/react-redux-spark-metrics';
 
 import LoadingScreen from '@webex/react-component-loading-screen';
 import ErrorDisplay from '@ciscospark/react-component-error-display';
@@ -48,7 +47,6 @@ const injectedPropTypes = {
   incomingCall: PropTypes.object,
   media: PropTypes.object.isRequired,
   mercuryStatus: PropTypes.object.isRequired,
-  metrics: PropTypes.object.isRequired,
   spaces: PropTypes.object.isRequired,
   spacesList: PropTypes.array.isRequired,
   sparkInstance: PropTypes.object,
@@ -106,20 +104,6 @@ export class RecentsWidget extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    RecentsWidget.checkForMercuryErrors(nextProps);
-    RecentsWidget.setup(nextProps);
-    this.addListeners(nextProps);
-    this.fetchAllAvatars(nextProps);
-  }
-
-  shouldComponentUpdate(nextProps) {
-    return nextProps.spacesList !== this.props.spacesList
-      || nextProps.errors !== this.props.errors
-      || nextProps.widgetRecents !== this.props.widgetRecents
-      || nextProps.incomingCall !== this.props.incomingCall;
-  }
-
   static setup(props) {
     const {
       errors,
@@ -127,7 +111,6 @@ export class RecentsWidget extends Component {
       sparkInstance,
       sparkState,
       mercuryStatus,
-      metrics,
       widgetStatus
     } = props;
 
@@ -197,9 +180,20 @@ export class RecentsWidget extends Component {
         }
       }
     }
-    if (widgetStatus.hasFetchedRecentSpaces) {
-      metrics.sendEndMetric(metricEvents.WIDGET_LOAD);
-    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    RecentsWidget.checkForMercuryErrors(nextProps);
+    RecentsWidget.setup(nextProps);
+    this.addListeners(nextProps);
+    this.fetchAllAvatars(nextProps);
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps.spacesList !== this.props.spacesList
+      || nextProps.errors !== this.props.errors
+      || nextProps.widgetRecents !== this.props.widgetRecents
+      || nextProps.incomingCall !== this.props.incomingCall;
   }
 
   @autobind

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -104,6 +104,20 @@ export class RecentsWidget extends Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    RecentsWidget.checkForMercuryErrors(nextProps);
+    RecentsWidget.setup(nextProps);
+    this.addListeners(nextProps);
+    this.fetchAllAvatars(nextProps);
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return nextProps.spacesList !== this.props.spacesList
+      || nextProps.errors !== this.props.errors
+      || nextProps.widgetRecents !== this.props.widgetRecents
+      || nextProps.incomingCall !== this.props.incomingCall;
+  }
+
   static setup(props) {
     const {
       errors,
@@ -180,20 +194,6 @@ export class RecentsWidget extends Component {
         }
       }
     }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    RecentsWidget.checkForMercuryErrors(nextProps);
-    RecentsWidget.setup(nextProps);
-    this.addListeners(nextProps);
-    this.fetchAllAvatars(nextProps);
-  }
-
-  shouldComponentUpdate(nextProps) {
-    return nextProps.spacesList !== this.props.spacesList
-      || nextProps.errors !== this.props.errors
-      || nextProps.widgetRecents !== this.props.widgetRecents
-      || nextProps.incomingCall !== this.props.incomingCall;
   }
 
   @autobind

--- a/packages/node_modules/@ciscospark/widget-recents/src/index.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/index.js
@@ -14,7 +14,7 @@ export default compose(
     name: 'recents',
     reducers
   }),
-  withIntl({locale: 'en', messages}),
+  mercuryEnhancer,
   mediaEnhancer,
-  mercuryEnhancer
+  withIntl({locale: 'en', messages})
 )(ConnectedRecents);

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/setup.js
@@ -2,7 +2,6 @@ import {compose, lifecycle} from 'recompose';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {events as metricEvents} from '@ciscospark/react-redux-spark-metrics';
 import {fetchAvatar} from '@ciscospark/redux-module-avatar';
 import {resetErrors} from '@ciscospark/redux-module-errors';
 import {constructHydraId, hydraTypes, isUuid} from '@ciscospark/react-component-utils';
@@ -98,7 +97,6 @@ function setup(props, prevProps) {
     errors,
     sparkInstance,
     sparkState,
-    metrics,
     spaceDetails,
     widgetStatus
   } = props;
@@ -152,7 +150,6 @@ function setup(props, prevProps) {
     }
 
     if (conversation.get('id')) {
-      metrics.sendEndMetric(metricEvents.WIDGET_LOAD);
       props.fetchAvatar({space: conversation.toJS()}, sparkInstance);
     }
   }


### PR DESCRIPTION
Every once in a while client metrics causes bugs in our code that breaks the widgets. The current implementation is not great and probably producing some bad metrics. We'll remove it for now until we have time to implement it correctly. Maybe with segment