### PR TITLE
fix(tooling): use proper shell result for git commands

### DIFF
--- a/scripts/utils/git.js
+++ b/scripts/utils/git.js
@@ -5,24 +5,12 @@ const {shellSync} = require('execa');
 
 const debug = require('debug')('tooling:git');
 
-exports.diff = async function diff(tag) {
-  debug(`diffing HEAD against ${tag}`);
-  debug(`Shelling out to \`git diff --name-only HEAD..${tag}\``);
-  const raw = String(shellSync(`git diff --name-only HEAD..${tag}`));
-
-  debug('Done');
-
-  // This mapping is probably unecessary, but it's kept to minimize the number
-  // of changes necessary to remove nodegit
-  return raw.split('\n').map((r) => ({path: r}));
-};
-
 exports.lastLog = function lastLog() {
   // When we're running on Jenkins, we know there's an env var called GIT_COMMIT
   const treeLike = process.env.GIT_COMMIT || 'HEAD';
   const cmd = `git log -n 1 --format=%B ${treeLike}`;
   debug(`Shelling out to ${cmd}`);
-  const log = String(shellSync(cmd));
+  const {stdout} = shellSync(cmd);
   debug('Done');
-  return log;
+  return stdout;
 };


### PR DESCRIPTION
When we switched to the `execa` method of running commands, the previous `String()` method of interpreting the results no longer works.

Also removed the unused `diff` command, since we hardcode diff into the Jenkinsfile. If needed in the future, we can get the current version from the sdk package.