### PR TITLE
feat(redux-module-media): ignore inactive created calls

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
@@ -136,6 +136,7 @@ Array [
           "remoteVideoStream": "",
           "sendingAudio": "",
           "sendingVideo": "",
+          "state": "active",
           "status": "",
         },
         "isActive": undefined,
@@ -207,6 +208,7 @@ Array [
           "remoteVideoStream": "",
           "sendingAudio": "",
           "sendingVideo": "",
+          "state": "active",
           "status": "",
         },
         "isActive": undefined,
@@ -286,6 +288,7 @@ Array [
           "remoteVideoStream": "",
           "sendingAudio": "",
           "sendingVideo": "",
+          "state": "active",
           "status": "",
         },
         "isActive": undefined,
@@ -413,6 +416,7 @@ Array [
           "remoteVideoStream": "",
           "sendingAudio": "",
           "sendingVideo": "",
+          "state": "active",
           "status": "",
         },
         "isActive": undefined,
@@ -509,6 +513,7 @@ Array [
           "remoteVideoStream": "",
           "sendingAudio": "",
           "sendingVideo": "",
+          "state": "active",
           "status": "",
         },
         "isActive": undefined,
@@ -535,6 +540,20 @@ Array [
       "id": "https://locusUrl",
     },
     "type": "media/STORE_CALL",
+  },
+]
+`;
+
+exports[`redux-module-media actions  #listenForCalls should not store inactive created calls 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "status": Object {
+        "isListening": true,
+        "isListeningToIncoming": true,
+      },
+    },
+    "type": "media/UPDATE_STATUS",
   },
 ]
 `;
@@ -587,6 +606,7 @@ Array [
           "remoteVideoStream": "",
           "sendingAudio": "",
           "sendingVideo": "",
+          "state": "active",
           "status": "",
         },
         "isActive": undefined,

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
@@ -375,13 +375,16 @@ function handleIncomingCalls(sparkInstance, dispatch) {
  */
 function handleCreatedCalls(sparkInstance, dispatch) {
   return sparkInstance.phone.on('call:created', (createdCall) => {
-    // If the call ends before we accept/decline
-    createdCall.once('inactive', () => {
-      createdCall.off();
-      return dispatch(removeCall(createdCall));
-    });
+    // Do not store call when a created inactive call comes in
+    if (createdCall.state !== 'inactive') {
+      // If the call ends before we accept/decline
+      createdCall.once('inactive', () => {
+        createdCall.off();
+        return dispatch(removeCall(createdCall));
+      });
+      dispatch(storeCall(createdCall));
+    }
 
-    dispatch(storeCall(createdCall));
     return Promise.resolve(createdCall);
   });
 }

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
@@ -28,6 +28,7 @@ describe('redux-module-media actions ', () => {
       direction: '',
       joined: '',
       joinedOnThisDevice: '',
+      state: 'active',
       status: '',
       receivingAudio: '',
       sendingAudio: '',
@@ -144,6 +145,18 @@ describe('redux-module-media actions ', () => {
           return callback(call)
             .then(() => {
               expect(call.once.mock.calls[0][0]).toBe('inactive');
+              expect(store.getActions()).toMatchSnapshot();
+            });
+        }));
+
+    it('should not store inactive created calls', () =>
+      store.dispatch(actions.listenForCalls(mockSpark))
+        .then(([, {eventName, callback}]) => {
+          expect(mockSpark.phone.on).toHaveBeenCalled();
+          expect(eventName).toBe('call:created');
+          call.state = 'inactive';
+          return callback(call)
+            .then(() => {
               expect(store.getActions()).toMatchSnapshot();
             });
         }));


### PR DESCRIPTION
Do not store inactive calls that come in as a created call. 

When placing a call and hanging up before the other party answers, we get a locus event about our disconnection in the form of a participant update. Unfortunately, since the call went to “inactive” due to the user hanging up, the sdk already removed the call from the “emittedCalls” collection.  The sdk emits a “call:created” event because it sees it as a new call (one that isn’t in the emittedCalls collection). 