### PR TITLE
fix(widget-recents): re-add missing event fields

### DIFF
--- a/packages/node_modules/@ciscospark/widget-meet/src/components/call-active/styles.css
+++ b/packages/node_modules/@ciscospark/widget-meet/src/components/call-active/styles.css
@@ -39,6 +39,7 @@
   right: 0;
   width: 100%;
   height: 100%;
+  position: absolute;
 }
 
 .callConnected .remoteVideo {

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -48,7 +48,8 @@ const injectedPropTypes = {
   media: PropTypes.object.isRequired,
   mercuryStatus: PropTypes.object.isRequired,
   spaces: PropTypes.object.isRequired,
-  spacesList: PropTypes.array.isRequired,
+  spacesList: PropTypes.object.isRequired,
+  spacesListArray: PropTypes.array.isRequired,
   sparkInstance: PropTypes.object,
   sparkState: PropTypes.object.isRequired,
   users: PropTypes.object.isRequired,
@@ -300,23 +301,26 @@ export class RecentsWidget extends Component {
   processActivity(activity, space) {
     const {props, handleEvent} = this;
     const {
-      currentUser
+      currentUser,
+      users,
+      spacesList
     } = props;
     props.storeActivities([activity]);
     const isSelf = activity.actor.id === currentUser.id;
+    const formattedSpace = spacesList.get(space.id);
     switch (activity.verb) {
       case 'share':
       case 'post': {
         const currentUserEmail = currentUser.email;
-        const otherUser = space.participants
+        const otherUserId = space.participants
           .find((p) => p.emailAddress !== currentUserEmail);
-
+        const otherUser = users.getIn(['byId', otherUserId]);
         // Update space with newest post activity
         props.updateSpaceWithActivity(activity, isSelf, true);
 
         // Do not emit unread if current user created the message
         if (!isSelf) {
-          handleEvent(eventNames.SPACES_UNREAD, constructRoomsEventData(space, activity));
+          handleEvent(eventNames.SPACES_UNREAD, constructRoomsEventData(formattedSpace, activity));
         }
         // Emit message:created event
         handleEvent(eventNames.MESSAGES_CREATED, constructMessagesEventData(activity, otherUser));
@@ -331,7 +335,7 @@ export class RecentsWidget extends Component {
         if (isSelf) {
         // update space with last acknowledgment if it's this user
           props.updateSpaceRead(activity.target.id, activity.published);
-          handleEvent(eventNames.SPACES_READ, constructRoomsEventData(space, activity));
+          handleEvent(eventNames.SPACES_READ, constructRoomsEventData(formattedSpace, activity));
         }
         break;
       }
@@ -424,13 +428,13 @@ export class RecentsWidget extends Component {
 
   @autobind
   handleSpaceClick(spaceId) {
-    const space = this.props.spaces.get(spaceId);
+    const space = this.props.spacesList.get(spaceId);
     this.handleEvent(eventNames.SPACES_SELECTED, constructRoomsEventData(space));
   }
 
   @autobind
   handleSpaceCallClick(spaceId) {
-    const space = this.props.spaces.get(spaceId);
+    const space = this.props.spacesList.get(spaceId);
     const roomData = constructRoomsEventData(space);
     this.handleEvent(eventNames.SPACES_SELECTED, {
       action: eventNames.ACTION_CALL,
@@ -456,7 +460,7 @@ export class RecentsWidget extends Component {
     if (data.call) {
       logData.call = '--- OMITTED ---';
     }
-    sparkInstance.logger.info(`event handler - ${name} - ${data.action}`, logData);
+    sparkInstance.logger.info(`event handler - ${name}`, logData);
     if (typeof onEvent === 'function') {
       this.props.onEvent(name, data);
     }
@@ -522,7 +526,7 @@ export class RecentsWidget extends Component {
     const {
       errors,
       media,
-      spacesList,
+      spacesListArray,
       currentUser,
       widgetStatus
     } = props;
@@ -542,8 +546,8 @@ export class RecentsWidget extends Component {
 
     const isWebRTCSupported = media.getIn(['webRTC', 'isSupported']);
 
-    if (spacesList && hasFetchedSpaces) {
-      const spacesListWithActivityText = spacesList.map((space) => {
+    if (spacesListArray && hasFetchedSpaces) {
+      const spacesListWithActivityText = spacesListArray.map((space) => {
         const s = Object.assign({}, space);
         s.activityText = this.constructActivityText(space);
         return s;

--- a/packages/node_modules/@ciscospark/widget-recents/src/events.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/events.js
@@ -23,7 +23,7 @@ export function constructMessagesEventData(activity, toUser) {
   let files, toPersonEmail, toPersonId;
 
   if (roomType === 'direct' && toUser) {
-    toPersonEmail = toUser.emailAddress;
+    toPersonEmail = toUser.email;
     toPersonId = constructHydraId(hydraTypes.PEOPLE, toUser.id);
   }
 

--- a/packages/node_modules/@ciscospark/widget-recents/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/selector.js
@@ -166,14 +166,14 @@ const getRecentsWidgetProps = createSelector(
     if (spacesList && spacesList.count()) {
       lastActivityDate = spacesList.last().lastActivityTimestamp;
     }
-    const spacesListArray = spacesList.toArray();
     return {
       widgetStatus: widget.get('status').toJS(),
       sparkState: spark.get('status').toJS(),
       sparkInstance: spark.get('spark'),
       widgetRecents: widget,
       spaces,
-      spacesList: spacesListArray,
+      spacesList,
+      spacesListArray: spacesList.toArray(),
       lastActivityDate,
       incomingCall,
       mercuryStatus: mercuryStatus.toJS()

--- a/test/journeys/lib/events.js
+++ b/test/journeys/lib/events.js
@@ -37,7 +37,7 @@ export function getEventLog(myBrowser) {
  * @param {object} options
  * @param {array} options.events
  * @param {string} options.eventName
- * @returns {(array|boolean)}
+ * @returns {(array)}
  */
 export function findEventName({events, eventName}) {
   if (Array.isArray(events)) {

--- a/test/journeys/lib/events.js
+++ b/test/journeys/lib/events.js
@@ -29,3 +29,19 @@ export function getEventLog(myBrowser) {
   });
   return result.value;
 }
+
+/**
+ * Searches events object for matching event name
+ *
+ * @export
+ * @param {object} options
+ * @param {array} options.events
+ * @param {string} options.eventName
+ * @returns {(array|boolean)}
+ */
+export function findEventName({events, eventName}) {
+  if (Array.isArray(events)) {
+    return events.filter((val) => val.eventName === eventName);
+  }
+  return [];
+}

--- a/test/journeys/testplan.md
+++ b/test/journeys/testplan.md
@@ -311,13 +311,15 @@ The "recents" test suite opens a recents widget and does things via the sdk that
     - displays a new incoming message
     - removes unread indicator when read
     - displays a call button on hover
-    - events
-      - messages:created
-      - rooms:unread
-      - rooms:read
-      - rooms:selected
-      - memberships:created
-      - memberships:deleted
+  - events
+    - messages:created - group space
+    - messages:created - one on one space
+    - rooms:unread
+    - rooms:read
+    - rooms:selected - group space
+    - rooms:selected - one on one space
+    - memberships:created
+    - memberships:deleted
   - one on one space
     - displays a new incoming message
     - removes unread indicator when read


### PR DESCRIPTION
At some point during the recents list changes a few weeks back the spaces list reference got switched to raw spaces and the events were missing the fields needed to create full events. I added those back in and put in some event tests in the journey tests to at least check fields are not empty.