### PR TITLE
filter update content activities from store

### DIFF
--- a/packages/node_modules/@ciscospark/react-component-activity-system-message/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-activity-system-message/src/index.js
@@ -27,7 +27,7 @@ export const SYSTEM_MESSAGE_VERBS = [
 const propTypes = {
   activity: PropTypes.shape({
     duration: PropTypes.number,
-    isGroupCall: PropTypes.bool.isRequired,
+    isGroupCall: PropTypes.bool,
     participants: PropTypes.shape({
       items: PropTypes.arrayOf(
         PropTypes.shape({

--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/__snapshots__/reducer.test.js.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`redux module conversation reducer ADD_ACTIVITIES_TO_CONVERSATION should add activities to the conversation 1`] = `
+Immutable.Map {
+  "activities": Immutable.OrderedMap {
+    "http://activity.url/abc-123": Object {
+      "id": "abc-123",
+      "mock": true,
+      "object": Object {
+        "displayName": "11",
+        "objectType": "comment",
+      },
+      "published": 1505420755171,
+      "url": "http://activity.url/abc-123",
+    },
+  },
+  "id": null,
+  "inFlightParticipants": Immutable.Map {
+    "adding": Immutable.Map {},
+    "removing": Immutable.Map {},
+  },
+  "lastAcknowledgedActivityId": null,
+  "participants": Immutable.List [],
+  "status": Immutable.Map {
+    "isListeningToMercury": false,
+    "error": null,
+    "isOneOnOne": null,
+    "isLoaded": false,
+    "isFetching": false,
+    "isLoadingMissing": false,
+    "isLocked": true,
+    "addParticipantError": null,
+    "removeParticipantError": null,
+    "isModerator": false,
+    "isLoadingHistoryUp": false,
+  },
+}
+`;
+
+exports[`redux module conversation reducer ADD_ACTIVITIES_TO_CONVERSATION should filter content update activities 1`] = `
+Immutable.Map {
+  "activities": Immutable.OrderedMap {
+    "http://activity.url/abc-123": Object {
+      "id": "abc-123",
+      "mock": true,
+      "object": Object {
+        "displayName": "11",
+        "objectType": "comment",
+      },
+      "published": 1505420755171,
+      "url": "http://activity.url/abc-123",
+    },
+  },
+  "id": null,
+  "inFlightParticipants": Immutable.Map {
+    "adding": Immutable.Map {},
+    "removing": Immutable.Map {},
+  },
+  "lastAcknowledgedActivityId": null,
+  "participants": Immutable.List [],
+  "status": Immutable.Map {
+    "isListeningToMercury": false,
+    "error": null,
+    "isOneOnOne": null,
+    "isLoaded": false,
+    "isFetching": false,
+    "isLoadingMissing": false,
+    "isLocked": true,
+    "addParticipantError": null,
+    "removeParticipantError": null,
+    "isModerator": false,
+    "isLoadingHistoryUp": false,
+  },
+}
+`;
+
 exports[`redux module conversation reducer ADD_PARTICIPANT should handle add participant and remove from in flight 1`] = `
 Immutable.Map {
   "activities": Immutable.OrderedMap {},
@@ -123,39 +197,6 @@ Immutable.Map {
     "removing": Immutable.Map {},
   },
   "lastAcknowledgedActivityId": "abc-123",
-  "participants": Immutable.List [],
-  "status": Immutable.Map {
-    "isListeningToMercury": false,
-    "error": null,
-    "isOneOnOne": null,
-    "isLoaded": false,
-    "isFetching": false,
-    "isLoadingMissing": false,
-    "isLocked": true,
-    "addParticipantError": null,
-    "removeParticipantError": null,
-    "isModerator": false,
-    "isLoadingHistoryUp": false,
-  },
-}
-`;
-
-exports[`redux module conversation reducer should handle ADD_ACTIVITIES_TO_CONVERSATION 1`] = `
-Immutable.Map {
-  "activities": Immutable.OrderedMap {
-    "http://activity.url/abc-123": Object {
-      "id": "abc-123",
-      "mock": true,
-      "published": 1505420755171,
-      "url": "http://activity.url/abc-123",
-    },
-  },
-  "id": null,
-  "inFlightParticipants": Immutable.Map {
-    "adding": Immutable.Map {},
-    "removing": Immutable.Map {},
-  },
-  "lastAcknowledgedActivityId": null,
   "participants": Immutable.List [],
   "status": Immutable.Map {
     "isListeningToMercury": false,

--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/actions.js
@@ -330,12 +330,13 @@ export function loadPreviousMessages(conversationId, maxDate, spark) {
       conversationId,
       lastActivityFirst: true,
       limit: 20,
-      maxDate
+      maxDate: Date.parse(maxDate) || Date.now()
     })
       .then((activities) => {
         dispatch(addActivitiesToConversation(activities));
         dispatch(updateConversationState({isLoadingHistoryUp: false}));
-      });
+      })
+      .catch((error) => dispatch(updateConversationState({error: error.message})));
   };
 }
 

--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.js
@@ -40,6 +40,19 @@ export const initialState = fromJS({
   }
 });
 
+/**
+ * Filters a raw list of activities for those we are interested in
+ *
+ * @param {array} activities
+ * @returns {array}
+ */
+function filterActivities(activities) {
+  // to make sure received activities are contiguous, remove the update
+  // activities with object.objectType `content`
+  return activities.filter((a) =>
+    a.verb !== 'update' &&
+    a.object && a.object.objectType !== 'content');
+}
 
 function receiveMercuryActivity(state, action) {
   let activities = state.get('activities');
@@ -80,7 +93,8 @@ export default function reducer(state = initialState, action) {
       return state.set('lastAcknowledgedActivityId', action.payload.activity.id);
     }
     case ADD_ACTIVITIES_TO_CONVERSATION: {
-      const addedActivities = new OrderedMap(action.payload.activities.map((activity) => [activity.url, activity]));
+      const filteredActivities = filterActivities(action.payload.activities);
+      const addedActivities = new OrderedMap(filteredActivities.map((activity) => [activity.url, activity]));
       let activities = state.get('activities').mergeDeep(addedActivities);
       activities = activities.sortBy((activity) => activity.published);
       return state.set('activities', activities);
@@ -121,7 +135,7 @@ export default function reducer(state = initialState, action) {
         status
       } = action.payload.conversation;
 
-      const conversationActivities = action.payload.conversation.activities.items;
+      const conversationActivities = filterActivities(action.payload.conversation.activities.items);
 
       let activities = new OrderedMap(conversationActivities.map((activity) => [activity.url, activity]));
       activities = activities.sortBy((activity) => activity.published);

--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.test.js
@@ -184,19 +184,55 @@ describe('redux module conversation reducer', () => {
     })).toMatchSnapshot();
   });
 
-  it('should handle ADD_ACTIVITIES_TO_CONVERSATION', () => {
-    expect(reducer(initialState, {
-      type: ADD_ACTIVITIES_TO_CONVERSATION,
-      payload: {
-        activities: [{
-          id: 'abc-123',
-          published: 1505420755171,
-          url: 'http://activity.url/abc-123',
-          mock: true
-        }]
-      }
-    })).toMatchSnapshot();
+  describe('ADD_ACTIVITIES_TO_CONVERSATION', () => {
+    it('should add activities to the conversation', () => {
+      expect(reducer(initialState, {
+        type: ADD_ACTIVITIES_TO_CONVERSATION,
+        payload: {
+          activities: [{
+            id: 'abc-123',
+            object: {
+              objectType: 'comment',
+              displayName: '11'
+            },
+            published: 1505420755171,
+            url: 'http://activity.url/abc-123',
+            mock: true
+          }]
+        }
+      })).toMatchSnapshot();
+    });
+
+    it('should filter content update activities', () => {
+      expect(reducer(initialState, {
+        type: ADD_ACTIVITIES_TO_CONVERSATION,
+        payload: {
+          activities: [{
+            id: 'abc-123',
+            object: {
+              objectType: 'comment',
+              displayName: '11'
+            },
+            published: 1505420755171,
+            url: 'http://activity.url/abc-123',
+            mock: true
+          },
+          {
+            id: 'abc-123-filter-me',
+            object: {
+              objectType: 'content',
+              displayName: '11'
+            },
+            published: 1505420755171,
+            url: 'http://activity.url/abc-123',
+            verb: 'update',
+            mock: true
+          }]
+        }
+      })).toMatchSnapshot();
+    });
   });
+
 
   describe('ADD_PARTICIPANT', () => {
     it('should handle add participant and remove from in flight', () => {

--- a/packages/node_modules/@ciscospark/widget-message/src/__snapshots__/selector.test.js.snap
+++ b/packages/node_modules/@ciscospark/widget-message/src/__snapshots__/selector.test.js.snap
@@ -7,6 +7,7 @@ Object {
     "2",
     "3",
   ],
+  "activitiesStatus": undefined,
   "activityCount": 3,
   "conversationId": "abc-123",
   "firstActivity": "1",

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -80,6 +80,9 @@ import {destinationTypes} from './';
 const injectedPropTypes = {
   avatar: PropTypes.object.isRequired,
   activity: PropTypes.object.isRequired,
+  activitiesStatus: PropTypes.shape({
+    isLoadingHistoryUp: PropTypes.bool
+  }).isRequired,
   conversation: PropTypes.object.isRequired,
   flags: PropTypes.object.isRequired,
   sparkInstance: PropTypes.object,
@@ -636,7 +639,8 @@ export class MessageWidget extends Component {
     const {
       conversationId,
       firstActivity,
-      sparkInstance
+      sparkInstance,
+      activitiesStatus
     } = props;
 
     if (activityList.isScrolledToBottom()) {
@@ -649,7 +653,7 @@ export class MessageWidget extends Component {
       props.setScrolledUp(true);
     }
 
-    if (activityList.isScrolledToTop() && firstActivity.verb !== 'create') {
+    if (activityList.isScrolledToTop() && firstActivity.verb !== 'create' && !activitiesStatus.isLoadingHistoryUp) {
       // Store scroll position before loading messages so the window
       // doesn't jump after they load
       props.setScrollPosition({scrollTop: activityList.getScrollTop()});

--- a/packages/node_modules/@ciscospark/widget-message/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/selector.js
@@ -58,6 +58,11 @@ export const getSpace = createSelector(
   }
 );
 
+const getActivitiesStatus = createSelector(
+  [getConversation],
+  (conversation) => conversation.get('status').toJS()
+);
+
 const getMessageWidgetProps = createSelector(
   [
     getSparkInstance,
@@ -65,12 +70,14 @@ const getMessageWidgetProps = createSelector(
     getConversation,
     getParticipants,
     getActivities,
-    getSpace
+    getSpace,
+    getActivitiesStatus
   ],
-  (sparkInstance, sparkState, conversation, participants, activities, space) => {
+  (sparkInstance, sparkState, conversation, participants, activities, space, activitiesStatus) => {
     const propsObject = {
       activities: activities.toJS(),
       activityCount: activities.count(),
+      activitiesStatus,
       lastActivity: activities.last(),
       firstActivity: activities.first(),
       conversationId: conversation.get('id'),


### PR DESCRIPTION
Content update activities come back from the conversation api out of (published time) order, so we need to remove them from the store and not count them in our max date calculation.

(Most of this code was taken from the web client's handling of activities)