### PR TITLE
fix(token-input): update aria labels to match previous use

### DIFF
--- a/packages/node_modules/@webex/private-react-component-token-input/src/index.js
+++ b/packages/node_modules/@webex/private-react-component-token-input/src/index.js
@@ -70,18 +70,18 @@ class TokenInput extends Component {
             <CardText expandable>
               <div className={style.select}>
                 <RadioButtonGroup
-                  aria-label="Access Token Type"
+                  aria-label="Choose Access Token Type"
                   name="tokenType"
                   onChange={this.handleTypeChange}
                   valueSelected={this.state.tokenType}
                 >
                   <RadioButton
-                    aria-label="Access Token"
+                    aria-label="Type Access Token"
                     label="Access Token"
                     value=""
                   />
                   <RadioButton
-                    aria-label="Guest Token"
+                    aria-label="Type Guest Token"
                     label="Guest Token"
                     value="JWT"
                   />


### PR DESCRIPTION
Tap tests may fail due to the aria labels being the same for input and radio buttons