### PR TITLE
fix(tap): clear cookies after tests

### DIFF
--- a/test/journeys/specs/tap/widget-recents/index.js
+++ b/test/journeys/specs/tap/widget-recents/index.js
@@ -82,7 +82,9 @@ describe('Widget Recents', () => {
   after('disconnect', () => Promise.all([
     marty.spark.internal.mercury.disconnect(),
     lorraine.spark.internal.mercury.disconnect(),
-    docbrown.spark.internal.mercury.disconnect()
+    docbrown.spark.internal.mercury.disconnect(),
+    // Demos use cookies to save state, clear before moving on
+    browser.deleteCookie()
   ]));
 
   before('create group space', () => marty.spark.internal.conversation.create({

--- a/test/journeys/specs/tap/widget-space/oneOnOne.js
+++ b/test/journeys/specs/tap/widget-space/oneOnOne.js
@@ -45,6 +45,9 @@ describe('Widget Space: One on One: TAP', () => {
     remote.browser.waitForExist(`[placeholder="Send a message to ${local.displayName}"]`, 30000);
   });
 
+  // Demos use cookies to save state, clear before moving on
+  after('delete cookies', () => browser.deleteCookie());
+
   describe('Activity Menu', () => {
     it('has a menu button', () => {
       assert.isTrue(local.browser.isVisible(basicElements.menuButton));

--- a/test/journeys/specs/tap/widget-space/space.js
+++ b/test/journeys/specs/tap/widget-space/space.js
@@ -81,7 +81,10 @@ describe('Widget Space: Group Space: TAP', () => {
 
   after('disconnect', () => Promise.all([
     marty.spark.internal.mercury.disconnect(),
-    lorraine.spark.internal.mercury.disconnect()
+    lorraine.spark.internal.mercury.disconnect(),
+    // Demos use cookies to save state, clear before moving on
+    browserLocal.deleteCookie(),
+    browserRemote.deleteCookie()
   ]));
 
   before('create space', () => marty.spark.internal.conversation.create({


### PR DESCRIPTION
When moving to another test suite, previous user was still logged in. Added a flush of the cookies in an "after" block for each tap test.