### PR TITLE
Fix nvm/npm prefix incompatibility

### DIFF
--- a/Jenkinsfile.tap
+++ b/Jenkinsfile.tap
@@ -39,6 +39,9 @@ pipeline {
             sh '''#!/bin/bash -e
             source ~/.nvm/nvm.sh
             nvm use v8.11.3
+            # Fix 'nvm is not compatible with the npm config "prefix" option'
+            npm config delete prefix
+            # Run tests
             CISCOSPARK_CLIENT_ID=C873b64d70536ed26df6d5f81e01dafccbd0a0af2e25323f7f69c7fe46a7be340 SAUCE=true npm run test:tap
             '''
           }

--- a/Jenkinsfile.tap
+++ b/Jenkinsfile.tap
@@ -39,7 +39,9 @@ pipeline {
             sh '''#!/bin/bash -e
             source ~/.nvm/nvm.sh
             nvm use v8.11.3
-            # Fix 'nvm is not compatible with the npm config "prefix" option'
+            # Fix 'nvm is not compatible with the npm config "prefix" option'.
+            # This error can happen when this agent's NODE_JS_BUILDER
+            # alters the environment.
             npm config delete prefix
             # Run tests
             CISCOSPARK_CLIENT_ID=C873b64d70536ed26df6d5f81e01dafccbd0a0af2e25323f7f69c7fe46a7be340 SAUCE=true npm run test:tap

--- a/package-lock.json
+++ b/package-lock.json
@@ -674,9 +674,9 @@
       }
     },
     "@ciscospark/test-helper-retry": {
-      "version": "1.32.22",
-      "resolved": "https://registry.npmjs.org/@ciscospark/test-helper-retry/-/test-helper-retry-1.32.22.tgz",
-      "integrity": "sha1-zJR+AppeE/y6cxBrDU/kLfaLR18=",
+      "version": "1.34.2",
+      "resolved": "https://registry.npmjs.org/@ciscospark/test-helper-retry/-/test-helper-retry-1.34.2.tgz",
+      "integrity": "sha512-bXY4POl5jECVW6DL/TVIDMeA4RNKsPTURpSidN+4K6FqANh86/I5Ot3D6IFolKj3HW1CSso+IYqQdoOQaAS7Dg==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -710,12 +710,12 @@
       }
     },
     "@ciscospark/test-helper-test-users": {
-      "version": "1.32.22",
-      "resolved": "https://registry.npmjs.org/@ciscospark/test-helper-test-users/-/test-helper-test-users-1.32.22.tgz",
-      "integrity": "sha1-Y+E+thfbgwPizvAGL0wq1YaV0sw=",
+      "version": "1.34.2",
+      "resolved": "https://registry.npmjs.org/@ciscospark/test-helper-test-users/-/test-helper-test-users-1.34.2.tgz",
+      "integrity": "sha512-sDiWh9JTYxr0UnSTzF0W8rccE4OrbYMDbOg2IgWJ5Zb3tLrmhy4ElwrTYDOloPxtOx1H9T0pC7baU0IiEhY8bQ==",
       "dev": true,
       "requires": {
-        "@ciscospark/test-helper-retry": "1.32.22",
+        "@ciscospark/test-helper-retry": "1.34.2",
         "@ciscospark/test-users-legacy": "1.0.2",
         "babel-runtime": "6.26.0",
         "envify": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@ciscospark/test-helper-appid": "1.32.22",
     "@ciscospark/test-helper-file": "1.32.22",
     "@ciscospark/test-helper-server": "1.32.22",
-    "@ciscospark/test-helper-test-users": "1.32.22",
+    "@ciscospark/test-helper-test-users": "^1.34.2",
     "axe-core": "^2.3.1",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",


### PR DESCRIPTION
-  Fix 'nvm is not compatible with the npm config "prefix". This error can happen when this agent's NODE_JS_BUILDER alters the environment.
- Upgrade package.