### PR TITLE
Greenkeeper/postcss modules 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18900,15 +18900,64 @@
       }
     },
     "postcss-modules": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-0.8.0.tgz",
-      "integrity": "sha1-qdAYBt/+GcJgfe6I6hy9gNwFmZI=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-1.3.2.tgz",
+      "integrity": "sha512-QujH5ZpPtr1fBWTKDa43Hx45gm7p19aEtHaAtkMCBZZiB/D5za2wXSMtAf94tDUZHF3F5KZcTXISUNqgEQRiDw==",
       "dev": true,
       "requires": {
         "css-modules-loader-core": "1.1.0",
         "generic-names": "1.0.3",
-        "postcss": "6.0.23",
+        "lodash.camelcase": "4.3.0",
+        "postcss": "7.0.2",
         "string-hash": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "postcss": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+          "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "postcss-modules-extract-imports": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "postcss-cli": "^4.1.0",
     "postcss-cssnext": "^3.0.2",
     "postcss-loader": "2.1.1",
-    "postcss-modules": "^0.8.0",
+    "postcss-modules": "^1.1.0",
     "postcss-reporter": "^5.0.0",
     "react-test-renderer": "^16.1.0",
     "react-transform-hmr": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "postcss-cli": "^4.1.0",
     "postcss-cssnext": "^3.0.2",
     "postcss-loader": "2.1.1",
-    "postcss-modules": "^1.1.0",
+    "postcss-modules": "^1.3.2",
     "postcss-reporter": "^5.0.0",
     "react-test-renderer": "^16.1.0",
     "react-transform-hmr": "^1.0.4",


### PR DESCRIPTION
Closes #818 and #530 

Manual testing looks good with the latest version.