### PR TITLE
fix(r-m-conversation): apply proper update content filter

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/__snapshots__/reducer.test.js.snap
@@ -74,6 +74,45 @@ Immutable.Map {
 }
 `;
 
+exports[`redux module conversation reducer ADD_ACTIVITIES_TO_CONVERSATION should not filter content activities 1`] = `
+Immutable.Map {
+  "activities": Immutable.OrderedMap {
+    "http://activity.url/abc-123": Object {
+      "id": "abc-123-dont-filter-me-bro",
+      "mock": true,
+      "note": "this should be in snapshot",
+      "object": Object {
+        "displayName": "11",
+        "objectType": "content",
+      },
+      "published": 1505420755171,
+      "url": "http://activity.url/abc-123",
+      "verb": "share",
+    },
+  },
+  "id": null,
+  "inFlightParticipants": Immutable.Map {
+    "adding": Immutable.Map {},
+    "removing": Immutable.Map {},
+  },
+  "lastAcknowledgedActivityId": null,
+  "participants": Immutable.List [],
+  "status": Immutable.Map {
+    "isListeningToMercury": false,
+    "error": null,
+    "isOneOnOne": null,
+    "isLoaded": false,
+    "isFetching": false,
+    "isLoadingMissing": false,
+    "isLocked": true,
+    "addParticipantError": null,
+    "removeParticipantError": null,
+    "isModerator": false,
+    "isLoadingHistoryUp": false,
+  },
+}
+`;
+
 exports[`redux module conversation reducer ADD_PARTICIPANT should handle add participant and remove from in flight 1`] = `
 Immutable.Map {
   "activities": Immutable.OrderedMap {},

--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.js
@@ -50,8 +50,8 @@ function filterActivities(activities) {
   // to make sure received activities are contiguous, remove the update
   // activities with object.objectType `content`
   return activities.filter((a) =>
-    a.verb !== 'update' &&
-    a.object && a.object.objectType !== 'content');
+    !(a.verb === 'update' &&
+    a.object && a.object.objectType === 'content'));
 }
 
 function receiveMercuryActivity(state, action) {

--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.test.js
@@ -226,7 +226,38 @@ describe('redux module conversation reducer', () => {
             published: 1505420755171,
             url: 'http://activity.url/abc-123',
             verb: 'update',
+            mock: true,
+            note: 'this should not be in snapshot'
+          }]
+        }
+      })).toMatchSnapshot();
+    });
+
+    it('should not filter content activities', () => {
+      expect(reducer(initialState, {
+        type: ADD_ACTIVITIES_TO_CONVERSATION,
+        payload: {
+          activities: [{
+            id: 'abc-123',
+            object: {
+              objectType: 'comment',
+              displayName: '11'
+            },
+            published: 1505420755171,
+            url: 'http://activity.url/abc-123',
             mock: true
+          },
+          {
+            id: 'abc-123-dont-filter-me-bro',
+            object: {
+              objectType: 'content',
+              displayName: '11'
+            },
+            published: 1505420755171,
+            url: 'http://activity.url/abc-123',
+            verb: 'share',
+            mock: true,
+            note: 'this should be in snapshot'
           }]
         }
       })).toMatchSnapshot();

--- a/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/index.js
@@ -44,7 +44,7 @@ class DemoWidget extends Component {
     };
     this.state = {
       activities: {
-        files: isMeetOnly ? false : activities.file,
+        files: isMeetOnly ? false : activities.files,
         meet: activities.meet,
         message: isMeetOnly ? false : activities.message,
         people: activities.people

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
@@ -44,7 +44,7 @@ class DemoWidgetSpace extends Component {
     };
     this.state = {
       activities: {
-        files: isMeetOnly ? false : activities.file,
+        files: isMeetOnly ? false : activities.files,
         meet: activities.meet,
         message: isMeetOnly ? false : activities.message,
         people: activities.people


### PR DESCRIPTION
The `if` logic was a bit off and filtering too many conversation activities causing file attachments coming from the conversation server to not be shown.

There is also a commit for a quick demo fix. I can separate into a different PR if needed.