### PR TITLE
test(journeys): skip start call setting test

### DIFF
--- a/test/journeys/specs/space/dataApi/startup-settings.js
+++ b/test/journeys/specs/space/dataApi/startup-settings.js
@@ -128,7 +128,7 @@ describe('Widget Space: Data API Settings', () => {
     });
   });
 
-  describe('start call setting', () => {
+  describe.skip('start call setting', () => {
     before('inject docbrown token', () => {
       browserRemote.execute((localAccessToken, spaceId) => {
         const csmmDom = document.createElement('div');


### PR DESCRIPTION
This test fails due to it showing a call already in progress.
Until we can determine the cause (bug ticket SPARK-36716), skip the failing test.