### PR TITLE
Use project based npmrc for publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,9 +255,7 @@ ansiColor('xterm') {
                 string(credentialsId: 'WIDGETS_NPM_PUBLISH_TOKEN', variable: 'WIDGETS_NPM_TOKEN')
               ]) {
                 try {
-                  // Copy & update config file
-                  sh 'cp .npmrc $HOME/.npmrc'
-                  sh 'echo \'//registry.npmjs.org/:_authToken=${WIDGETS_NPM_TOKEN}\' >> $HOME/.npmrc'
+                  sh 'echo \'//registry.npmjs.org/:_authToken=${WIDGETS_NPM_TOKEN}\' >> .npmrc'
                   // Publish
                   echo ''
                   echo 'Reminder: E403 errors below are normal. They occur for any package that has no updates to publish'
@@ -266,6 +264,7 @@ ansiColor('xterm') {
                   source ~/.nvm/nvm.sh
                   nvm use v8.11.3
                   npm run publish:components
+                  git checkout .npmrc
                   '''
                 }
                 catch (error) {


### PR DESCRIPTION
I cannot find any documentation anymore that says publish tokens must be in the user's npmrc file. Going to attempt this, but if it fails, I'll do another PR for cleaning up the home directory npmrc.