### PR TITLE
Add constraints to incoming call answer

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`redux-module-media actions  #acceptIncomingCall can accept an incoming call with constraints 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "call": Object {
+        "activeParticipantsCount": 0,
+        "direction": "",
+        "hasJoinedOnThisDevice": "",
+        "instance": Object {
+          "acknowledge": [MockFunction],
+          "answer": [MockFunction] {
+            "calls": Array [
+              Array [
+                Object {
+                  "constraints": Object {
+                    "audio": true,
+                    "video": false,
+                  },
+                  "offerOptions": Object {
+                    "offerToReceiveAudio": true,
+                    "offerToReceiveVideo": true,
+                  },
+                },
+              ],
+            ],
+          },
+          "direction": "",
+          "hangup": [MockFunction],
+          "joined": "",
+          "joinedOnThisDevice": "",
+          "localMediaStream": "",
+          "locus": Object {
+            "fullState": Object {
+              "lastActive": "Sun Feb 18 2018 18:21:05 GMT",
+            },
+            "url": "https://locusUrl",
+          },
+          "off": [MockFunction],
+          "on": [MockFunction],
+          "once": [MockFunction],
+          "receivingAudio": "",
+          "reject": [MockFunction],
+          "remoteAudioMuted": "",
+          "remoteAudioStream": "",
+          "remoteMediaStream": "",
+          "remoteVideoMuted": "",
+          "remoteVideoStream": "",
+          "sendingAudio": "",
+          "sendingVideo": "",
+          "state": "active",
+          "status": "",
+        },
+        "isActive": undefined,
+        "isCall": undefined,
+        "isConnected": false,
+        "isDeclined": undefined,
+        "isIncoming": false,
+        "isInitiated": false,
+        "isReceivingAudio": "",
+        "isReceivingVideo": undefined,
+        "isRinging": undefined,
+        "isSendingAudio": "",
+        "isSendingVideo": "",
+        "localMediaStream": "",
+        "locusUrl": undefined,
+        "memberships": Array [],
+        "remoteAudioMuted": "",
+        "remoteAudioStream": null,
+        "remoteMediaStream": "",
+        "remoteVideoMuted": "",
+        "remoteVideoStream": null,
+        "startTime": undefined,
+      },
+      "eventName": undefined,
+      "id": "abc-123",
+    },
+    "type": "media/UPDATE_CALL_STATUS",
+  },
+]
+`;
+
 exports[`redux-module-media actions  #acceptIncomingCall can successfully accept an incoming call 1`] = `
 Array [
   Object {
@@ -14,6 +95,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
+                  "constraints": undefined,
                   "offerOptions": Object {
                     "offerToReceiveAudio": true,
                     "offerToReceiveVideo": true,

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
@@ -101,11 +101,15 @@ function updateWebRTCSupport(supported) {
  *
  * @export
  * @param {object} incomingCall
+ * @param {object} constraints rtc constraints for getmedia request
+ * @param {boolean} constraints.audio
+ * @param {object} constraints.video
  * @returns {Promise}
  */
-export function acceptIncomingCall(incomingCall) {
+export function acceptIncomingCall(incomingCall, constraints) {
   return (dispatch) =>
     incomingCall.instance.answer({
+      constraints,
       offerOptions: {offerToReceiveVideo: true, offerToReceiveAudio: true}
     })
       .then(() => {

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
@@ -73,6 +73,15 @@ describe('redux-module-media actions ', () => {
           expect(callInstance.answer).toHaveBeenCalled();
           expect(store.getActions()).toMatchSnapshot();
         }));
+
+    it('can accept an incoming call with constraints', () => {
+      const constraints = {audio: true, video: false};
+      store.dispatch(actions.acceptIncomingCall(callObject, constraints))
+        .then(() => {
+          expect(callInstance.answer).toHaveBeenCalled();
+          expect(store.getActions()).toMatchSnapshot();
+        });
+    });
   });
 
   describe('#checkCurrentCalls', () => {

--- a/packages/node_modules/@ciscospark/widget-meet/src/enhancers/withCallHandlers.js
+++ b/packages/node_modules/@ciscospark/widget-meet/src/enhancers/withCallHandlers.js
@@ -64,7 +64,9 @@ function catchCallError(props) {
 
 function handleAnswer(props) {
   return () => {
-    props.acceptIncomingCall(props.call);
+    const {call, hasVideo} = props;
+    const constraints = {audio: true, video: hasVideo};
+    props.acceptIncomingCall(call, constraints);
   };
 }
 

--- a/scripts/webpack/webpack.transpile.babel.js
+++ b/scripts/webpack/webpack.transpile.babel.js
@@ -10,6 +10,7 @@ const libraryName = pkg.name;
 module.exports = (env) => {
   console.info('webpacking for transpile');
   return {
+    devtool: 'source-map',
     entry: './src/index.js',
     output: {
       path: path.resolve(process.cwd(), 'es'),
@@ -155,8 +156,6 @@ module.exports = (env) => {
     },
     resolve: {
       alias: {
-        react: path.resolve(__dirname, './node_modules/react'),
-        'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
         assets: path.resolve(__dirname, 'assets'),
         node_modules: path.resolve(__dirname, '..', '..', 'node_modules')
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,10 @@
   "exclude": [
     "packages/node_modules/@ciscospark/**/dist/*",
     "packages/node_modules/@webex/**/dist/*",
+    "packages/node_modules/@ciscospark/**/es/*",
+    "packages/node_modules/@webex/**/es/*",
+    "packages/node_modules/@ciscospark/**/cjs/*",
+    "packages/node_modules/@webex/**/cjs/*",
     "node_modules/**/*",
     "dist"
   ]


### PR DESCRIPTION
We had the smarts to not display video on an audio only call, but we didn't tell that to the sdk when answering the call. It was throwing an error trying to display the video in an element that didn't exist.

![img](https://media1.giphy.com/media/CIvOSdr87NWVy/giphy.gif?cid=e1bb72ff5bc790416f66797a63e4ce47)