### PR TITLE
chore(Jenkinsfile): update public path for demo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,7 +210,7 @@ ansiColor('xterm') {
               BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/" npm run build:package widget-recents
               BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/" npm run build sri widget-recents
               BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/" BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/demo/" npm run build:package widget-recents-demo
-              BUILD_PUBLIC_PATH="https://code.s4d.io/widget-demo/archives/${version}/demo/" npm run build:package widget-demo
+              BUILD_PUBLIC_PATH="https://code.s4d.io/widget-demo/archives/${version}/" npm run build:package widget-demo
               '''
             }
           }


### PR DESCRIPTION
The public path variable is what gets injected into the webpack build of the `index.html` file. I had set it to the incorrect path.