### PR TITLE
feat(widget-space): ability to control selected activity externally

### DIFF
--- a/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/external-control.js
+++ b/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/external-control.js
@@ -1,0 +1,117 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import {Radio, RadioGroup} from '@collab-ui/react';
+
+class ExternalControl extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activity: props.activity
+      // sendMessage: '',
+      // startCall: false
+    };
+
+    this.handleActivityChange = this.handleActivityChange.bind(this);
+    // this.handleSendMessageChange = this.handleSendMessageChange.bind(this);
+    // this.handleStartCallChange = this.handleStartCallChange.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({activity: nextProps.activity});
+  }
+
+  handleActivityChange(value) {
+    this.setState({activity: value});
+    this.props.onChangeActivity(value);
+  }
+
+  // handleSendMessageChange(e) {
+  //   const {value} = e.target;
+  //   this.setState({sendMessage: value});
+  //   this.props.onChangeSendMessage(value);
+  // }
+
+  // handleStartCallChange(value) {
+  //   this.setState({startCall: value});
+  //   this.props.onChangeStartCall(value);
+  // }
+
+  render() {
+    return (
+      <div>
+        <h3>Change Current Activity</h3>
+        <RadioGroup
+          ariaLabel="Change Activity"
+          name="changeActivity"
+          onChange={this.handleActivityChange}
+          values={[this.state.activity]}
+        >
+          <Radio
+            ariaLabel="Message"
+            htmlId="changeActivityMessage"
+            label="Message"
+            value="message"
+          />
+          <Radio
+            ariaLabel="Meet"
+            htmlId="changeActivityMeet"
+            label="Meet"
+            value="meet"
+          />
+          <Radio
+            ariaLabel="People"
+            htmlId="changeActivityPeople"
+            label="People"
+            value="people"
+          />
+        </RadioGroup>
+        {/* <h3>Start Call</h3>
+        <RadioGroup
+          ariaLabel="Start Call"
+          name="changeActivity"
+          onChange={this.handleStartCallChange}
+          values={[this.state.startCall]}
+        >
+          <Radio
+            ariaLabel="True"
+            htmlId="changeStartCallTrue"
+            label="True"
+            value="true"
+          />
+          <Radio
+            ariaLabel="False"
+            htmlId="changeStartCallFalse"
+            label="False"
+            value=""
+          />
+        </RadioGroup>
+        <div>
+          <h3> Send Message </h3>
+          <Input
+            aria-label="Send Message"
+            htmlId="sendMessage"
+            inputSize="medium-12"
+            onChange={this.handleSendMessageChange}
+            placeholder="Send a message to the space"
+            value={this.state.sendMessage}
+          />
+        </div> */}
+      </div>
+    );
+  }
+}
+
+ExternalControl.propTypes = {
+  activity: PropTypes.string,
+  onChangeActivity: PropTypes.func.isRequired
+  // onChangeSendMessage: PropTypes.func.isRequired,
+  // onChangeStartCall: PropTypes.func.isRequired
+};
+
+ExternalControl.defaultProps = {
+  activity: ''
+};
+
+export default ExternalControl;

--- a/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/index.js
@@ -6,12 +6,14 @@ import {autobind} from 'core-decorators';
 
 import {Button, Topbar} from '@collab-ui/react';
 
-import SpaceWidget from '@ciscospark/widget-space';
+import SpaceWidget, {eventNames as spaceEvents} from '@ciscospark/widget-space';
 import RecentsWidget from '@ciscospark/widget-recents';
 
 import TokenInput from '@webex/private-react-component-token-input';
 import SpaceDestination, {constants as destinationConstants} from '@webex/private-react-component-space-destination';
 import ExampleCode from '@webex/private-react-component-example-code';
+
+import ExternalControl from './external-control';
 
 import './collab.scss';
 import styles from './styles.css';
@@ -54,6 +56,7 @@ class DemoWidget extends Component {
       mode,
       recentsRunning: false,
       recentsWidgetProps: {},
+      setCurrentActivity: '',
       spaceRunning: false,
       spaceWidgetProps: {},
       stickyMode: false
@@ -165,6 +168,11 @@ class DemoWidget extends Component {
   }
 
   @autobind
+  handleChangeActivity(value) {
+    return this.setState({setCurrentActivity: value});
+  }
+
+  @autobind
   handleToggleStickyMode() {
     this.setState((state) => (
       {stickyMode: !state.stickyMode}
@@ -179,6 +187,9 @@ class DemoWidget extends Component {
       initialActivity: this.state.initialActivity,
       onEvent: (eventName, detail) => {
         window.ciscoSparkEvents.push({eventName, detail});
+        if (eventName === spaceEvents.ACTIVITY_CHANGED) {
+          this.setState({setCurrentActivity: ''});
+        }
       },
       spaceActivities: this.state.activities
     };
@@ -191,6 +202,9 @@ class DemoWidget extends Component {
 
     widgetOptions.destinationId = destinationId;
     widgetOptions.destinationType = destinationType;
+
+    // External Control Props
+    widgetOptions.setCurrentActivity = this.state.setCurrentActivity;
 
     this.setState({spaceRunning: true, spaceWidgetProps: widgetOptions});
   }
@@ -277,17 +291,25 @@ class DemoWidget extends Component {
               <h2>Space Widget</h2>
               <p>The Webex Teams Space widget allows developers to easily incorporate Webex Teams Space messaging and meeting into an application.</p>
               <div>
-                <SpaceDestination
-                  activities={this.state.activities}
-                  destinationId={this.state.destinationId}
-                  initialActivity={this.state.initialActivity}
-                  mode={this.state.mode}
-                  onActivitiesChange={this.handleActivitiesChange}
-                  onDestinationChange={this.handleDestinationChange}
-                  onDestinationPropTypeChange={this.handleDestinationPropTypeChange}
-                  onInitialActivityChange={this.handleInitialActivityChange}
-                  onModeChange={this.handleModeChange}
-                />
+                { !this.state.spaceRunning &&
+                  <SpaceDestination
+                    activities={this.state.activities}
+                    destinationId={this.state.destinationId}
+                    initialActivity={this.state.initialActivity}
+                    mode={this.state.mode}
+                    onActivitiesChange={this.handleActivitiesChange}
+                    onDestinationChange={this.handleDestinationChange}
+                    onDestinationPropTypeChange={this.handleDestinationPropTypeChange}
+                    onInitialActivityChange={this.handleInitialActivityChange}
+                    onModeChange={this.handleModeChange}
+                  />
+                }
+                { this.state.spaceRunning &&
+                  <ExternalControl
+                    activity={this.state.setCurrentActivity}
+                    onChangeActivity={this.handleChangeActivity}
+                  />
+                }
               </div>
               <div>
                 <Button

--- a/packages/node_modules/@ciscospark/widget-space/README.md
+++ b/packages/node_modules/@ciscospark/widget-space/README.md
@@ -131,6 +131,16 @@ When loading the widgets there are some configuration options you can provide:
 | `toPersonEmail` | `data-to-person-email` | Email of the message recipient |
 | `toPersonId` | `data-to-person-id` | User Id of the message recipient |
 
+### External Control
+
+The space widget allows for developers to control actions and behaviors via properties. These properties, when set, will make the widget perform certain actions, like switching to different activities.
+
+**Note:** these actions are triggered by the properties changing from empty to populated. This means to perform a second action, the property will need to be set back to empty before changing.
+
+| Name | Description |
+|:--|---|
+| `setCurrentActivity` | Sets the user's current activity in the widget. Possible cases are `meet` or `message`. |
+
 ### HTML
 
 The easiest way to get the Webex Teams Space Widget into your web site is to add the built resources and attach data attributes to your a container.

--- a/packages/node_modules/@ciscospark/widget-space/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/container.js
@@ -39,6 +39,7 @@ export const ownPropTypes = {
   destinationId: PropTypes.string,
   destinationType: PropTypes.oneOf(['email', 'userId', 'spaceId', 'sip', 'pstn']),
   muteNotifications: PropTypes.bool,
+  setCurrentActivity: PropTypes.string,
   spaceActivities: PropTypes.shape({
     files: PropTypes.bool,
     meet: PropTypes.bool,
@@ -61,6 +62,7 @@ const defaultProps = {
   destinationId: null,
   destinationType: null,
   muteNotifications: false,
+  setCurrentActivity: '',
   spaceActivities: {
     files: true,
     meet: true,

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/activity-menu.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/activity-menu.js
@@ -109,6 +109,8 @@ function handleActivityChange(props) {
     else {
       props.updateSecondaryActivityType(activity.name);
     }
+    // Emit Event
+    props.onEvent(eventNames.ACTIVITY_CHANGED, activity);
   };
 }
 

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/external-control.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/external-control.js
@@ -3,6 +3,8 @@ import {compose, lifecycle} from 'recompose';
 import {bindActionCreators} from 'redux';
 import {addError, removeError} from '@ciscospark/redux-module-errors';
 
+import {eventNames} from '../events';
+
 import {ACTIVITY_TYPE_PRIMARY, ACTIVITY_TYPE_SECONDARY} from './activity-menu';
 
 function changeCurrentActivity(props) {
@@ -21,7 +23,8 @@ function changeCurrentActivity(props) {
       // Secondary activities need to have the menu opened
       props.updateSecondaryActivityType(setCurrentActivity);
     }
-    props.onSetCurrentActivity(setCurrentActivity);
+    // Emit Event
+    props.onEvent(eventNames.ACTIVITY_CHANGED, toActivity);
   }
 }
 

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/external-control.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/external-control.js
@@ -1,0 +1,52 @@
+import {connect} from 'react-redux';
+import {compose, lifecycle} from 'recompose';
+import {bindActionCreators} from 'redux';
+import {addError, removeError} from '@ciscospark/redux-module-errors';
+
+import {ACTIVITY_TYPE_PRIMARY, ACTIVITY_TYPE_SECONDARY} from './activity-menu';
+
+function changeCurrentActivity(props) {
+  const {
+    activityTypes,
+    setCurrentActivity
+  } = props;
+
+  // Check if activity is valid
+  const toActivity = activityTypes.find((activity) => activity.name === setCurrentActivity);
+  if (toActivity) {
+    if (toActivity.type === ACTIVITY_TYPE_PRIMARY) {
+      props.updateActivityType(setCurrentActivity);
+    }
+    if (toActivity.type === ACTIVITY_TYPE_SECONDARY) {
+      // Secondary activities need to have the menu opened
+      props.updateSecondaryActivityType(setCurrentActivity);
+    }
+    props.onSetCurrentActivity(setCurrentActivity);
+  }
+}
+
+function checkForExternalTrigger(nextProps, currentProps) {
+  const {
+    setCurrentActivity
+  } = nextProps;
+
+  // Change Current Activity
+  if (setCurrentActivity && setCurrentActivity !== currentProps.setCurrentActivity) {
+    changeCurrentActivity(nextProps);
+  }
+}
+
+export default compose(
+  connect(
+    (state) => state,
+    (dispatch) => bindActionCreators({
+      addError,
+      removeError
+    }, dispatch)
+  ),
+  lifecycle({
+    componentWillReceiveProps(nextProps) {
+      checkForExternalTrigger(nextProps, this.props);
+    }
+  })
+);

--- a/packages/node_modules/@ciscospark/widget-space/src/enhancers/index.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/enhancers/index.js
@@ -1,9 +1,11 @@
 import errors from './errors';
 import setup from './setup';
 import activityMenu from './activity-menu';
+import externalControl from './external-control';
 
 export default [
   setup,
   errors,
-  activityMenu
+  activityMenu,
+  externalControl
 ];

--- a/packages/node_modules/@ciscospark/widget-space/src/events.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/events.js
@@ -8,7 +8,8 @@ export const eventNames = {
   CALL_MEMBERSHIPS_NOTIFIED: 'calls:memberships:notified',
   CALL_MEMBERSHIPS_CONNECTED: 'calls:memberships:connected',
   CALL_MEMBERSHIPS_DECLINED: 'calls:memberships:declined',
-  CALL_MEMBERSHIPS_DISCONNECTED: 'calls:memberships:disconnected'
+  CALL_MEMBERSHIPS_DISCONNECTED: 'calls:memberships:disconnected',
+  ACTIVITY_CHANGED: 'activity:changed'
 };
 
 export default {

--- a/packages/node_modules/@ciscospark/widget-space/src/index.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/index.js
@@ -5,6 +5,10 @@ import {enhancer as mercuryEnhancer} from '@ciscospark/redux-module-mercury';
 import reducers from './reducer';
 import ConnectedSpace from './container';
 import messages from './translations/en';
+import events from './events';
+
+const {eventNames} = events;
+export {eventNames};
 
 export {reducers};
 

--- a/test/journeys/lib/test-helpers/demo.js
+++ b/test/journeys/lib/test-helpers/demo.js
@@ -16,7 +16,9 @@ export const elements = {
   toSpaceInput: 'input[aria-label="To Space ID"]',
   toPersonInput: 'input[aria-label="To User Email"]',
   spaceWidgetContainer: '#my-ciscospark-space-widget',
-  recentsWidgetContainer: '#my-ciscospark-recents-widget'
+  recentsWidgetContainer: '#my-ciscospark-recents-widget',
+  changeActivityMeetButton: 'label[for="changeActivityMeet"]',
+  updateSpaceWidgetButton: 'button[aria-label="Update Space Widget"]'
 };
 
 /**

--- a/test/journeys/specs/smoke/demo.js
+++ b/test/journeys/specs/smoke/demo.js
@@ -85,6 +85,15 @@ describe('demo widget', () => {
           verifyMessageReceipt(remote, local, docText, false);
         });
       });
+
+      describe('external control', () => {
+        it('can change current activity', () => {
+          assert.isTrue(browserLocal.isVisible(spaceElements.messageWidget));
+          browserLocal.click(elements.changeActivityMeetButton);
+          browserLocal.click(elements.updateSpaceWidgetButton);
+          browserLocal.waitForVisible(spaceElements.meetWidget, 6000);
+        });
+      });
     });
   });
 

--- a/test/journeys/testplan.md
+++ b/test/journeys/testplan.md
@@ -86,6 +86,8 @@ The smoke test suite verifies basic functionality of all widgets. This suite is 
     - closes the menu with the exit button
   - messaging
     - sends and receives messages
+  - External Control
+    - can change current activity
 - recents widget
   - opens and loads recents widget
 


### PR DESCRIPTION
Adds a react prop `setCurrentActivity` that allows react users of the widgets to control the current activity. 