### PR TITLE
feat(widget-demo): add sticky mode support

### DIFF
--- a/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/index.js
+++ b/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/index.js
@@ -55,7 +55,8 @@ class DemoWidget extends Component {
       recentsRunning: false,
       recentsWidgetProps: {},
       spaceRunning: false,
-      spaceWidgetProps: {}
+      spaceWidgetProps: {},
+      stickyMode: false
     };
   }
 
@@ -164,6 +165,13 @@ class DemoWidget extends Component {
   }
 
   @autobind
+  handleToggleStickyMode() {
+    this.setState((state) => (
+      {stickyMode: !state.stickyMode}
+    ));
+  }
+
+  @autobind
   openSpaceWidget({
     destinationId, destinationType
   }) {
@@ -244,7 +252,7 @@ class DemoWidget extends Component {
       componentRecentsContainerClassNames.push(styles.hidden);
     }
     const runningDemosContainerClassNames = [
-      styles.runningDemosContainer
+      this.state.stickyMode ? styles.runningDemosSticky : styles.runningDemosBottom
     ];
     if (!this.state.spaceRunning && !this.state.recentsRunning) {
       runningDemosContainerClassNames.push(styles.hidden);
@@ -349,6 +357,16 @@ class DemoWidget extends Component {
                   <SpaceWidget {...this.state.spaceWidgetProps} />
                 }
               </div>
+            </div>
+            <div className={styles.stickyButton}>
+              <Button
+                ariaLabel="Remove Recents Widget"
+                color="blue"
+                id="toggleStickyModeButton"
+                onClick={this.handleToggleStickyMode}
+              >
+                {this.state.stickyMode ? 'Unstick Widgets' : 'Stick Widgets'}
+              </Button>
             </div>
             <div className={classNames(componentRecentsContainerClassNames)}>
               <div id={recentsWidgetElementId}>

--- a/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/styles.css
+++ b/packages/node_modules/@ciscospark/widget-demo/src/components/demo-widget/styles.css
@@ -11,9 +11,14 @@ body {
   border-radius: 2px;
 }
 
-.runningDemosContainer {
-  position: relative;
+.runningDemosSticky {
+  position: sticky;
+  bottom: 0;
+}
+
+.runningDemosBottom {
   height: 625px;
+  position: relative;
   border: 1px solid;
   background-color: #39393b;
 }
@@ -61,4 +66,12 @@ body {
 
 .hidden {
   visibility: hidden;
+}
+
+/* Button at the center bottom that sticks widgets */
+.stickyButton {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
 }


### PR DESCRIPTION
This will make the loaded widgets "sticky" to the bottom of the screen vs having a dedicated space at the bottom of the page. 