### PR TITLE
Journey tests for react implementation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,7 @@ ansiColor('xterm') {
                 export ATLAS_SERVICE_URL='https://atlas-intb.ciscospark.com/admin/api/v1'
                 export WDM_SERVICE_URL='https://wdm-intb.ciscospark.com/wdm/api/v1'
 
-                NODE_ENV=test npm run build:package widget-space && npm run build:package widget-recents
+                NODE_ENV=test npm run build:package widget-space && npm run build:package widget-recents && npm run build:package widget-demo
                 export BUILD_NUMBER="pipeline-build-$BUILD_NUMBER"
                 set -m
                 (

--- a/scripts/build/commands/journey.js
+++ b/scripts/build/commands/journey.js
@@ -30,7 +30,8 @@ module.exports = {
             });
           return Promise.all([
             exec(`BUILD_DIST_PATH=${dest}/dist-space npm run build:package widget-space`),
-            exec(`BUILD_DIST_PATH=${dest}/dist-recents npm run build:package widget-recents`)
+            exec(`BUILD_DIST_PATH=${dest}/dist-recents npm run build:package widget-recents`),
+            exec(`BUILD_DIST_PATH=${dest}/dist-demo npm run build:package widget-demo`)
           ]);
         })
         .catch((err) => {

--- a/test/journeys/lib/test-helpers/demo.js
+++ b/test/journeys/lib/test-helpers/demo.js
@@ -1,0 +1,37 @@
+// @ts-check
+/**
+ * Test helpers for the tap tests that use material-ui as a front end
+ */
+
+import {assert} from 'chai';
+
+export const elements = {
+  accessTokenInput: 'input[aria-label="Access Token"]',
+  saveTokenButton: 'button[aria-label="Save Token"]',
+  clearTokenButton: 'button[aria-label="Clear Token"]',
+  toSpaceRadioButton: 'input[aria-label="To Space"]',
+  toPersonRadioButton: 'label[for="toTypeEmail"]',
+  openSpaceWidgetButton: 'button[aria-label="Open Space Widget"]',
+  openRecentsWidgetButton: 'button[aria-label="Open Recents Widget"]',
+  toSpaceInput: 'input[aria-label="To Space ID"]',
+  toPersonInput: 'input[aria-label="To User Email"]',
+  spaceWidgetContainer: '#my-ciscospark-space-widget',
+  recentsWidgetContainer: '#my-ciscospark-recents-widget'
+};
+
+/**
+ * Enters the access token into the token field and saves it
+ *
+ * @export
+ * @param {object} aBrowser
+ * @param {string} accessToken
+ */
+export function saveToken(aBrowser, accessToken) {
+  if (aBrowser.element(elements.clearTokenButton).isVisible()) {
+    aBrowser.element(elements.clearTokenButton).click();
+  }
+  aBrowser.waitUntil(() => aBrowser.element(elements.accessTokenInput).isVisible(), 3500, 'access token input field not found');
+  aBrowser.setValue(elements.accessTokenInput, accessToken);
+  assert.equal(aBrowser.element(elements.accessTokenInput).getValue(), accessToken, 'access token entry failed');
+  aBrowser.element(elements.saveTokenButton).click();
+}

--- a/test/journeys/lib/test-helpers/index.js
+++ b/test/journeys/lib/test-helpers/index.js
@@ -14,7 +14,8 @@ export const jobNames = {
   smokeInitial: 'react-widget-smoke-initial',
   smokeMultiple: 'react-widget-smoke-multiple',
   smokeRecents: 'react-widget-smoke-recents',
-  smokeSpace: 'react-widget-smoke-space'
+  smokeSpace: 'react-widget-smoke-space',
+  smokeDemo: 'react-widget-smoke-demo'
 };
 /**
  * Move mouse a specified amount of pixels

--- a/test/journeys/lib/test-helpers/space-widget/messaging.js
+++ b/test/journeys/lib/test-helpers/space-widget/messaging.js
@@ -60,20 +60,23 @@ export function sendMessage(sender, receiver, message) {
  * @param {TestObject} receiver
  * @param {TestObject} sender
  * @param {string} message
+ * @param {boolean} [sendReadReceipt=true]
  * @returns {void}
  */
-export function verifyMessageReceipt(receiver, sender, message) {
+export function verifyMessageReceipt(receiver, sender, message, sendReadReceipt = true) {
   receiver.browser.waitForVisible(`[placeholder="Send a message to ${sender.displayName}"]`);
   receiver.browser.waitForExist(elements.pendingActivity, 60000, true);
   receiver.browser.waitForExist(elements.lastActivityText);
   receiver.browser.waitUntil(() => receiver.browser.getText(elements.lastActivityText) === message);
-  // Move mouse to send read receipt
-  moveMouse(receiver.browser, elements.lastActivityText);
-  // Verify read receipt comes across
-  sender.browser.waitForExist(`${elements.readReceiptsArea} ${elements.readReceiptsAvatar}`);
-  // Move Mouse to text area so it doesn't cause any tool tips
-  moveMouse(receiver.browser, elements.messageComposer);
-  moveMouse(sender.browser, elements.messageComposer);
+  if (sendReadReceipt) {
+    // Move mouse to send read receipt
+    moveMouse(receiver.browser, elements.lastActivityText);
+    // Verify read receipt comes across
+    sender.browser.waitForExist(`${elements.readReceiptsArea} ${elements.readReceiptsAvatar}`);
+    // Move Mouse to text area so it doesn't cause any tool tips
+    moveMouse(receiver.browser, elements.messageComposer);
+    moveMouse(sender.browser, elements.messageComposer);
+  }
 }
 
 /**

--- a/test/journeys/specs/smoke/demo.js
+++ b/test/journeys/specs/smoke/demo.js
@@ -1,0 +1,104 @@
+import {assert} from 'chai';
+
+import {setupOneOnOneUsers} from '../../lib/test-users';
+import {elements, saveToken} from '../../lib/test-helpers/demo';
+import {elements as spaceElements} from '../../lib/test-helpers/space-widget/main';
+import {sendMessage, verifyMessageReceipt} from '../../lib/test-helpers/space-widget/messaging';
+import {jobNames, renameJob, updateJobStatus} from '../../lib/test-helpers';
+
+describe('demo widget', () => {
+  const browserLocal = browser.select('browserLocal');
+  const browserRemote = browser.select('browserRemote');
+  const jobName = jobNames.smokeDemo;
+  let allPassed = true;
+  let mccoy, spock, local, remote;
+
+  it('start new sauce session', () => {
+    browser.reload();
+    browser.call(() => renameJob(jobName, browser));
+
+    browserLocal.url('/dist-demo/index.html');
+    browserRemote.url('/dist-demo/index.html');
+  });
+
+  it('create test users', () => {
+    [mccoy, spock] = setupOneOnOneUsers();
+    local = {browser: browserLocal, user: mccoy, displayName: mccoy.displayName};
+    remote = {browser: browserRemote, user: spock, displayName: spock.displayName};
+  });
+
+  it('saves token for users', () => {
+    saveToken(browserLocal, mccoy.token.access_token);
+    saveToken(browserRemote, spock.token.access_token);
+  });
+
+  describe('space widget', () => {
+    it('opens space widget for mccoy in local', () => {
+      browserLocal.click(elements.toPersonRadioButton);
+      browserLocal.element(elements.toPersonInput).setValue(spock.email);
+      browserLocal.click(elements.openSpaceWidgetButton);
+      // Wait for conversation to be ready
+      const textInputField = `[placeholder="Send a message to ${spock.displayName}"]`;
+      browserLocal.waitForVisible(textInputField);
+      browserLocal.scroll(textInputField);
+    });
+
+    it('opens space widget for spock in remote', () => {
+      browserRemote.click(elements.toPersonRadioButton);
+      browserRemote.element(elements.toPersonInput).setValue(mccoy.email);
+      browserRemote.click(elements.openSpaceWidgetButton);
+      // Wait for conversation to be ready
+      const textInputFieldRemote = `[placeholder="Send a message to ${mccoy.displayName}"]`;
+      browserRemote.waitForVisible(textInputFieldRemote);
+      browserRemote.scroll(textInputFieldRemote);
+    });
+
+    describe('space widget functionality', () => {
+      describe('Activity Menu', () => {
+        it('has a menu button', () => {
+          assert.isTrue(browserLocal.isVisible(spaceElements.menuButton));
+        });
+
+        it('displays the menu when clicking the menu button', () => {
+          browserLocal.click(spaceElements.menuButton);
+          browserLocal.waitForVisible(spaceElements.activityMenu);
+        });
+
+        it('has an exit menu button', () => {
+          assert.isTrue(browserLocal.isVisible(spaceElements.activityMenu));
+          browserLocal.waitForVisible(spaceElements.exitButton);
+        });
+
+        it('closes the menu with the exit button', () => {
+          browserLocal.click(spaceElements.exitButton);
+          browserLocal.waitForVisible(spaceElements.activityMenu, 60000, true);
+        });
+      });
+
+      describe('messaging', () => {
+        it('sends and receives messages', () => {
+          const martyText = 'Wait a minute. Wait a minute, Doc. Ah... Are you telling me that you built a time machine... out of a DeLorean?';
+          const docText = 'The way I see it, if you\'re gonna build a time machine into a car, why not do it with some style?';
+          sendMessage(remote, local, martyText);
+          verifyMessageReceipt(local, remote, martyText, false);
+          sendMessage(local, remote, docText);
+          verifyMessageReceipt(remote, local, docText, false);
+        });
+      });
+    });
+  });
+
+  describe('recents widget', () => {
+    it('opens recents widget for mccoy in local', () => {
+      browserLocal.click(elements.openRecentsWidgetButton);
+      browserLocal.waitForVisible(elements.recentsWidgetContainer);
+    });
+  });
+
+  /* eslint-disable-next-line func-names */
+  afterEach(function () {
+    allPassed = allPassed && (this.currentTest.state === 'passed');
+  });
+
+  after(() => browser.call(() => updateJobStatus(jobName, allPassed)));
+});

--- a/test/journeys/testplan.md
+++ b/test/journeys/testplan.md
@@ -76,6 +76,19 @@ The smoke test suite verifies basic functionality of all widgets. This suite is 
   - meet widget
     - can hangup in call
 
+#### Demo Page Smoke Tests (Built from widget-demo)
+
+- space widget functionality
+  - Activity Menu
+    - has a menu button
+    - displays the menu when clicking the menu button
+    - has an exit menu button
+    - closes the menu with the exit button
+  - messaging
+    - sends and receives messages
+- recents widget
+  - opens and loads recents widget
+
 ### Space Widget Suite
 
 The space widget suite tests the functionality of the space widget in a given space. It also verifies by instantiating the widget in two separate ways: via the data-api and via the global javascript method.

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -71,7 +71,8 @@ let staticServerFolders = [
   {mount: '/dist-space', path: './packages/node_modules/@ciscospark/widget-space/dist'},
   {mount: '/dist-recents', path: './packages/node_modules/@ciscospark/widget-recents/dist'},
   {mount: '/', path: './test/journeys/server/'},
-  {mount: '/axe-core', path: './node_modules/axe-core/'}
+  {mount: '/axe-core', path: './node_modules/axe-core/'},
+  {mount: '/dist-demo', path: './packages/node_modules/@ciscospark/widget-demo/dist'}
 ];
 
 if (process.env.STATIC_SERVER_PATH) {
@@ -98,7 +99,8 @@ exports.config = {
     smoke: [
       './test/journeys/specs/smoke/widget-space/index.js',
       './test/journeys/specs/smoke/widget-recents/index.js',
-      './test/journeys/specs/smoke/multiple/index.js'
+      './test/journeys/specs/smoke/multiple/index.js',
+      './test/journeys/specs/smoke/demo.js'
     ],
     tap: [
       './test/journeys/specs/tap/**/*.js'


### PR DESCRIPTION
Since widget-demo uses all the widgets via react, might as well just test it.

We should be able to migrate our tap tests to use this test suite as well.