### PR TITLE
fix(r-m-users): add support for empty displayName

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-users/src/__snapshots__/helpers.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-users/src/__snapshots__/helpers.test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redux module users helpers #constructUser detects and converts a hydra user 1`] = `
+Object {
+  "displayName": "Johnny Karate",
+  "email": "thepit@mouserat.net",
+  "id": "whateverbro",
+  "nickName": "Burt Macklin",
+  "orgId": "my-org",
+  "status": Object {
+    "isFetching": false,
+  },
+}
+`;
+
+exports[`Redux module users helpers #constructUser detects and converts a participant user 1`] = `
+Object {
+  "displayName": "Johnny Karate",
+  "email": "thepit@mouserat.net",
+  "id": "1234",
+  "nickName": "Johnny",
+  "orgId": "pwn33",
+  "status": Object {
+    "isFetching": false,
+  },
+}
+`;
+
+exports[`Redux module users helpers #constructUserFromHydra converts a hydra object to user shape 1`] = `
+Object {
+  "displayName": "Johnny Karate",
+  "email": "thepit@mouserat.net",
+  "id": "whateverbro",
+  "nickName": "Burt Macklin",
+  "orgId": "my-org",
+  "status": Object {
+    "isFetching": false,
+  },
+}
+`;
+
+exports[`Redux module users helpers #constructUserFromHydra supports an empty user 1`] = `Object {}`;
+
+exports[`Redux module users helpers #constructUserFromParticipant converts a participant object to user shape 1`] = `
+Object {
+  "displayName": "Johnny Karate",
+  "email": "thepit@mouserat.net",
+  "id": "1234",
+  "nickName": "Johnny",
+  "orgId": "pwn33",
+  "status": Object {
+    "isFetching": false,
+  },
+}
+`;
+
+exports[`Redux module users helpers #constructUserFromParticipant supports an empty displayName 1`] = `
+Object {
+  "displayName": undefined,
+  "email": "thepit@mouserat.net",
+  "id": "1234",
+  "nickName": "",
+  "orgId": "pwn33",
+  "status": Object {
+    "isFetching": false,
+  },
+}
+`;

--- a/packages/node_modules/@ciscospark/redux-module-users/src/helpers.js
+++ b/packages/node_modules/@ciscospark/redux-module-users/src/helpers.js
@@ -4,7 +4,7 @@ export function constructUserFromParticipant(user) {
   return {
     id: user.id,
     displayName: user.displayName,
-    nickName: user.displayName.split(' ')[0],
+    nickName: user.displayName ? user.displayName.split(' ')[0] : '',
     email: user.emailAddress,
     orgId: user.orgId,
     status: {

--- a/packages/node_modules/@ciscospark/redux-module-users/src/helpers.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-users/src/helpers.test.js
@@ -1,0 +1,64 @@
+import {constructUserFromHydra, constructUserFromParticipant, constructUser} from './helpers';
+
+describe('Redux module users helpers', () => {
+  describe('#constructUserFromParticipant', () => {
+    it('converts a participant object to user shape', () => {
+      const user = {
+        id: '1234',
+        displayName: 'Johnny Karate',
+        emailAddress: 'thepit@mouserat.net',
+        orgId: 'pwn33'
+      };
+      expect(constructUserFromParticipant(user)).toMatchSnapshot();
+    });
+
+    it('supports an empty displayName', () => {
+      const user = {
+        id: '1234',
+        emailAddress: 'thepit@mouserat.net',
+        orgId: 'pwn33'
+      };
+      expect(constructUserFromParticipant(user)).toMatchSnapshot();
+    });
+  });
+
+  describe('#constructUserFromHydra', () => {
+    it('converts a hydra object to user shape', () => {
+      const user = {
+        id: 'Y2lzY29zcGFyazovL3VzL1BFUlNPTi93aGF0ZXZlcmJybw==',
+        displayName: 'Johnny Karate',
+        nickName: 'Burt Macklin',
+        emails: ['thepit@mouserat.net'],
+        orgId: 'Y2lzY29zcGFyazovL3VzL09SRy9teS1vcmc='
+      };
+      expect(constructUserFromHydra(user)).toMatchSnapshot();
+    });
+
+    it('supports an empty user', () => {
+      expect(constructUserFromHydra()).toMatchSnapshot();
+    });
+  });
+
+  describe('#constructUser', () => {
+    it('detects and converts a hydra user', () => {
+      const user = {
+        id: 'Y2lzY29zcGFyazovL3VzL1BFUlNPTi93aGF0ZXZlcmJybw==',
+        displayName: 'Johnny Karate',
+        nickName: 'Burt Macklin',
+        emails: ['thepit@mouserat.net'],
+        orgId: 'Y2lzY29zcGFyazovL3VzL09SRy9teS1vcmc='
+      };
+      expect(constructUser(user)).toMatchSnapshot();
+    });
+
+    it('detects and converts a participant user', () => {
+      const user = {
+        id: '1234',
+        displayName: 'Johnny Karate',
+        emailAddress: 'thepit@mouserat.net',
+        orgId: 'pwn33'
+      };
+      expect(constructUser(user)).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
In some instances, a participant object comes back with no displayName.