### PR TITLE
style(widget-roster): align external message

### DIFF
--- a/packages/node_modules/@ciscospark/widget-roster/src/components/external-participant/styles.css
+++ b/packages/node_modules/@ciscospark/widget-roster/src/components/external-participant/styles.css
@@ -1,5 +1,6 @@
 .external {
   display: flex;
+  align-items: center;
   height: 33px;
   margin: 8px;
   font-size: 10px;


### PR DESCRIPTION
The `People outside your company are included in this space` text was misaligned with the icon. This fixes the issue.

In regular mode:
![image](https://user-images.githubusercontent.com/190647/51127244-092dd080-17f3-11e9-9863-33efb478f2fb.png)

In full width mode:
![image](https://user-images.githubusercontent.com/190647/51127280-1fd42780-17f3-11e9-9620-05c35260019c.png)

