### PR TITLE
Avatars are not aligned

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "contributors": [
     "Adam Weeks <adweeks@cisco.com>",
     "Bernie Zang <nzang@cisco.com>",
-    "Moriah Maney <momaney@cisco.com>"
+    "Moriah Maney <momaney@cisco.com>",
+    "Arash Koushkebaghi <akoushke@cisco.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/packages/node_modules/@ciscospark/react-component-typing-avatar/src/styles.css
+++ b/packages/node_modules/@ciscospark/react-component-typing-avatar/src/styles.css
@@ -6,6 +6,7 @@
 }
 
 .avatar {
+  display: flex;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
<img width="201" alt="screen shot 2019-01-29 at 6 47 01 pm" src="https://user-images.githubusercontent.com/14226615/51954755-4f3f8280-23f6-11e9-9560-a62d234455f6.png">
The Avatars are aligned now.

How to test:
Open a space widget on a room that contains both types of avatars (initials and images) in the `read-receipts` div and make sure that they are aligned.