### PR TITLE
fix(widget-recents): fetch proper to user avatar in direct spaces

### DIFF
--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
@@ -16,20 +16,31 @@ import {
 import {updateSpaceTypeFilter, updateWidgetStatus} from '../actions';
 import getRecentsWidgetProps from '../selector';
 
-function getSpaceAvatar(s, props) {
-  const {sparkInstance} = props;
+/**
+ * Gets the avatar for a space
+ * Will fetch the user avatar for 1:1 spaces
+ *
+ * @export
+ * @param {Object} space
+ * @param {Object} props
+ */
+export function getSpaceAvatar(space, props) {
+  const {users, sparkInstance} = props;
 
-  if (!s.isDecrypting) {
+  if (!space.isDecrypting) {
     if (
-      s.type === 'direct'
-      && s.toPersonId
+      space.type === 'direct'
     ) {
-      props.fetchAvatar({userId: s.toPersonId}, sparkInstance);
+      // Find the participant that is not the current user
+      const toPersonId = space.participants.find((p) => p !== users.get('currentUserId'));
+
+      // Direct spaces use the "other participant" as the space avatar
+      props.fetchAvatar({userId: toPersonId}, sparkInstance);
     }
     else if (
-      s.type === 'group' && s.id
+      space.type === 'group' && space.id
     ) {
-      props.fetchAvatar({space: s}, sparkInstance);
+      props.fetchAvatar({space}, sparkInstance);
     }
   }
 }

--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
@@ -14,7 +14,7 @@ import {
 } from '@ciscospark/react-component-utils';
 
 import {updateSpaceTypeFilter, updateWidgetStatus} from '../actions';
-import {getSpaceWidgetProps} from '../selector';
+import getRecentsWidgetProps from '../selector';
 
 function getSpaceAvatar(s, props) {
   const {sparkInstance} = props;
@@ -218,7 +218,7 @@ export function setup(props) {
 
 export default compose(
   connect(
-    getSpaceWidgetProps,
+    getRecentsWidgetProps,
     (dispatch) => bindActionCreators({
       connectToMercury,
       fetchAvatar,

--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.test.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.test.js
@@ -1,4 +1,4 @@
-import {setup} from './setup';
+import {getSpaceAvatar, setup} from './setup';
 
 describe('widget-recents: enhancers: setup', () => {
   let props;
@@ -23,6 +23,9 @@ describe('widget-recents: enhancers: setup', () => {
         authenticated: false,
         registered: false,
         hasError: false
+      },
+      users: {
+        get: () => 'my-user-id'
       },
       widgetRecents: {
         spaceType: 'all'
@@ -194,18 +197,31 @@ describe('widget-recents: enhancers: setup', () => {
         props.spacesList = [
           {
             isDecrypting: false,
-            type: 'direct',
-            toPersonId: 'abc123'
+            participants: [
+              {
+                id: 'abc123'
+              },
+              {
+                id: 'my-user-id'
+              }
+            ],
+            type: 'direct'
           },
           {
             isDecrypting: false,
-            type: 'group',
-            toPersonId: 'abc123'
+            participants: [
+              {
+                id: 'abc123'
+              },
+              {
+                id: 'my-user-id'
+              }
+            ],
+            type: 'group'
           },
           {
             isDecrypting: true,
-            type: 'group',
-            toPersonId: 'abc123'
+            type: 'group'
           }
         ];
       });
@@ -242,6 +258,47 @@ describe('widget-recents: enhancers: setup', () => {
           expect(props.fetchSpaces).not.toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe('#getSpaceAvatar', () => {
+    it('should not fetch avatars for a decrypting space', () => {
+      const space = {
+        isDecrypting: true
+      };
+
+      getSpaceAvatar(space, props);
+
+      expect(props.fetchAvatar).not.toHaveBeenCalled();
+    });
+
+    it('should fetch the avatar for the group space id', () => {
+      const space = {
+        id: 'my-group-id',
+        isDecrypting: false,
+        type: 'group'
+      };
+
+      getSpaceAvatar(space, props);
+      const fetchConfig = props.fetchAvatar.mock.calls[0][0];
+
+      expect(fetchConfig.space.id).toEqual('my-group-id');
+    });
+
+    it('should fetch the avatar for the to person id', () => {
+      const space = {
+        isDecrypting: false,
+        participants: [
+          'my-user-id',
+          'to-user-id'
+        ],
+        type: 'direct'
+      };
+
+      getSpaceAvatar(space, props);
+      const fetchConfig = props.fetchAvatar.mock.calls[0][0];
+
+      expect(fetchConfig.userId).toEqual('to-user-id');
     });
   });
 });


### PR DESCRIPTION
We were trying to get the "toPersonId" space detail to fetch an avatar. Unfortunately, this is a calculated property, which isn't available on the direct object, so we have to calculate it manually.