### PR TITLE
Add options to #getSpaces for storing users and activities

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
@@ -466,6 +466,547 @@ Array [
 ]
 `;
 
+exports[`redux-module-space actions  #getSpaces supports shouldStoreActivities and shouldStoreUsers options being false 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "spaces": Array [
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+      ],
+    },
+    "type": "spaces/STORE_SPACES",
+  },
+]
+`;
+
+exports[`redux-module-space actions  #getSpaces supports shouldStoreActivities option being false 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "users": Array [
+        Object {
+          "displayName": "Person 1",
+          "email": "person1@email.com",
+          "id": "other-userid",
+          "nickName": "Person",
+          "orgId": "12345678-1234-1234-1234-123456789000",
+          "status": Object {
+            "isFetching": false,
+          },
+        },
+        Object {
+          "displayName": "Person 2",
+          "email": "person2@email.com",
+          "id": "this-user-id",
+          "nickName": "Person",
+          "orgId": "12345678-1234-1234-1234-123456789000",
+          "status": Object {
+            "isFetching": false,
+          },
+        },
+      ],
+    },
+    "type": "users/STORE_USERS",
+  },
+  Object {
+    "payload": Object {
+      "spaces": Array [
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+      ],
+    },
+    "type": "spaces/STORE_SPACES",
+  },
+]
+`;
+
+exports[`redux-module-space actions  #getSpaces supports shouldStoreUsers option being false 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "activities": Array [
+        Object {
+          "actor": "other-userid",
+          "id": "activityId",
+          "object": Object {
+            "displayName": "Great work team!!!",
+            "objectType": "comment",
+          },
+          "objectType": "activity",
+          "published": "2017-06-07T15:13:56.326Z",
+          "type": "post",
+          "url": "https://activityUrl",
+        },
+      ],
+    },
+    "type": "activities/STORE_ACTIVITIES",
+  },
+  Object {
+    "payload": Object {
+      "spaces": Array [
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+        Object {
+          "activities": Array [
+            "activityId",
+          ],
+          "avatar": Object {
+            "contentCategory": "images",
+            "files": Object {
+              "items": Array [
+                Object {
+                  "fileSize": 56520,
+                  "mimeType": "image/png",
+                  "objectType": "file",
+                  "scr": Object {},
+                  "url": "https://fileUrl",
+                },
+              ],
+            },
+            "objectType": "content",
+          },
+          "conversationWebUrl": "https://conversationWebUrl",
+          "displayName": "Space 1",
+          "id": "spaceId",
+          "isDecrypting": undefined,
+          "isHidden": false,
+          "isLocked": true,
+          "isMentionNotificationsOff": undefined,
+          "isMentionNotificationsOn": true,
+          "isMessageNotificationsOff": true,
+          "isMessageNotificationsOn": undefined,
+          "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+          "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+          "latestActivity": "activityId",
+          "locusUrl": "https://converstaionLocusUrl",
+          "participants": Array [
+            "other-userid",
+            "this-user-id",
+          ],
+          "published": "2016-02-29T17:49:17.029Z",
+          "tags": Array [
+            "MUTED",
+            "FAVORITE",
+            "LOCKED",
+            "TEAM",
+            "JOINED",
+            "MESSAGE_NOTIFICATIONS_OFF",
+            "MENTION_NOTIFICATIONS_ON",
+          ],
+          "team": "teamId",
+          "type": "group",
+          "url": "https://converstaionUrl",
+        },
+      ],
+    },
+    "type": "spaces/STORE_SPACES",
+  },
+]
+`;
+
 exports[`redux-module-space actions  #removeSpace properly removes a space 1`] = `
 Array [
   Object {

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
@@ -115,9 +115,19 @@ function decryptSpace(space) {
  * @export
  * @param {Object} sparkInstance
  * @param {Object} options
+ * @param {boolean} options.deferDecrypt defer the decryption until after download
+ * @param {boolean} options.shouldStoreUsers stores the users found in the spaces to the
+ *                                           users store
+ * @param {boolean} options.shouldStoreActivities stores the activities found in the spaces
+ *                                                to the activities store
  * @returns {Function} thunk
  */
 export function getSpaces(sparkInstance, options = {}) {
+  const {
+    deferDecrypt,
+    shouldStoreUsers = true,
+    shouldStoreActivities = true
+  } = options;
   const listOptions = Object.assign({
     uuidEntryFormat: true,
     personRefresh: true,
@@ -128,7 +138,6 @@ export function getSpaces(sparkInstance, options = {}) {
     allFavorite: true,
     participantsLimit: -1
   }, options);
-  const {deferDecrypt} = options;
 
   return (dispatch) => sparkInstance.internal.conversation
     .list(listOptions)
@@ -149,8 +158,13 @@ export function getSpaces(sparkInstance, options = {}) {
                 const participants = decryptedSpace.participants.items;
                 const activityActors = activities.map((a) => a.actor);
 
-                dispatch(storeUsers([...participants, ...activityActors]));
-                dispatch(storeActivities(decryptedActivities));
+                if (shouldStoreUsers) {
+                  dispatch(storeUsers([...participants, ...activityActors]));
+                }
+
+                if (shouldStoreActivities) {
+                  dispatch(storeActivities(decryptedActivities));
+                }
                 dispatch(storeSpaces([s]));
 
                 return Promise.resolve(constructSpace(s));
@@ -171,8 +185,14 @@ export function getSpaces(sparkInstance, options = {}) {
       const uniqueUsers = uniqBy(users, 'id');
       const uniqueActivities = uniqBy(activities, 'id');
 
-      dispatch(storeUsers(uniqueUsers));
-      dispatch(storeActivities(uniqueActivities));
+      if (shouldStoreUsers) {
+        dispatch(storeUsers(uniqueUsers));
+      }
+
+      if (shouldStoreActivities) {
+        dispatch(storeActivities(uniqueActivities));
+      }
+
       dispatch(storeSpaces(spaces));
 
       return Promise.resolve(spaces);

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
@@ -184,6 +184,33 @@ describe('redux-module-space actions ', () => {
         expect(store.getActions()).toMatchSnapshot();
       });
     });
+
+    it('supports shouldStoreUsers option being false', () => {
+      const options = {shouldStoreUsers: false};
+
+      store.dispatch(actions.getSpaces(mockSpark, options)).then(() => {
+        expect(mockSpark.internal.conversation.list).toHaveBeenCalledTimes(1);
+        expect(store.getActions()).toMatchSnapshot();
+      });
+    });
+
+    it('supports shouldStoreActivities option being false', () => {
+      const options = {shouldStoreActivities: false};
+
+      store.dispatch(actions.getSpaces(mockSpark, options)).then(() => {
+        expect(mockSpark.internal.conversation.list).toHaveBeenCalledTimes(1);
+        expect(store.getActions()).toMatchSnapshot();
+      });
+    });
+
+    it('supports shouldStoreActivities and shouldStoreUsers options being false', () => {
+      const options = {shouldStoreActivities: false, shouldStoreUsers: false};
+
+      store.dispatch(actions.getSpaces(mockSpark, options)).then(() => {
+        expect(mockSpark.internal.conversation.list).toHaveBeenCalledTimes(1);
+        expect(store.getActions()).toMatchSnapshot();
+      });
+    });
   });
 
   describe('#fetchSpace', () => {

--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
@@ -126,7 +126,9 @@ function getInitialSpaces(props) {
       lastViewableActivityOnly: false,
       // Defer decrypt allows us to show the encrypted spaces in the space list
       // before decrypting. Giving a better UX
-      deferDecrypt: true
+      deferDecrypt: true,
+      shouldStoreUsers: false,
+      shouldStoreActivities: false
     })
       .then((encryptedSpaces) => {
         // As the spaces decrypt, get the avatar for them
@@ -154,7 +156,9 @@ function getAllSpaces(props) {
     props.fetchSpaces(sparkInstance, {
       limit: 250,
       activitiesLimit: 0,
-      lastViewableActivityOnly: false
+      lastViewableActivityOnly: false,
+      shouldStoreUsers: false,
+      shouldStoreActivities: false
     })
       .then(() => {
         props.updateWidgetStatus({


### PR DESCRIPTION
Users and activities are not needed for rendering the recents widget. Since we fetch so many spaces, optimize the processing of the spaces and reduce the amount of writes to the redux store.

The space widget still needs these, so I made the storing configurable.