### PR TITLE
Remove storing of activities and users in fetch spaces

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
@@ -116,8 +116,24 @@ Array [
           "latestActivity": undefined,
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -231,8 +247,24 @@ Array [
           "latestActivity": "activityId",
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -255,54 +287,8 @@ Array [
 ]
 `;
 
-exports[`redux-module-space actions  #getSpaces properly gets spaces 1`] = `
+exports[`redux-module-space actions  #fetchSpaces properly fetches spaces 1`] = `
 Array [
-  Object {
-    "payload": Object {
-      "users": Array [
-        Object {
-          "displayName": "Person 1",
-          "email": "person1@email.com",
-          "id": "other-userid",
-          "nickName": "Person",
-          "orgId": "12345678-1234-1234-1234-123456789000",
-          "status": Object {
-            "isFetching": false,
-          },
-        },
-        Object {
-          "displayName": "Person 2",
-          "email": "person2@email.com",
-          "id": "this-user-id",
-          "nickName": "Person",
-          "orgId": "12345678-1234-1234-1234-123456789000",
-          "status": Object {
-            "isFetching": false,
-          },
-        },
-      ],
-    },
-    "type": "users/STORE_USERS",
-  },
-  Object {
-    "payload": Object {
-      "activities": Array [
-        Object {
-          "actor": "other-userid",
-          "id": "activityId",
-          "object": Object {
-            "displayName": "Great work team!!!",
-            "objectType": "comment",
-          },
-          "objectType": "activity",
-          "published": "2017-06-07T15:13:56.326Z",
-          "type": "post",
-          "url": "https://activityUrl",
-        },
-      ],
-    },
-    "type": "activities/STORE_ACTIVITIES",
-  },
   Object {
     "payload": Object {
       "spaces": Array [
@@ -340,8 +326,24 @@ Array [
           "latestActivity": "activityId",
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -391,8 +393,24 @@ Array [
           "latestActivity": "activityId",
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -442,8 +460,24 @@ Array [
           "latestActivity": "activityId",
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -530,8 +564,24 @@ Array [
           "latestActivity": "activityId",
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -593,8 +643,24 @@ Array [
           "latestActivity": "activityId",
           "locusUrl": "https://converstaionLocusUrl",
           "participants": Array [
-            "other-userid",
-            "this-user-id",
+            Object {
+              "displayName": "Person 1",
+              "emailAddress": "person1@email.com",
+              "entryEmail": "person1@email.com",
+              "id": "other-userid",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
+            Object {
+              "displayName": "Person 2",
+              "emailAddress": "person2@email.com",
+              "entryEmail": "person2@email.com",
+              "id": "this-user-id",
+              "objectType": "person",
+              "orgId": "12345678-1234-1234-1234-123456789000",
+              "type": "PERSON",
+            },
           ],
           "published": "2016-02-29T17:49:17.029Z",
           "tags": Array [
@@ -707,7 +773,7 @@ Object {
   "default": [Function],
   "fetchSpace": [Function],
   "fetchSpaces": [Function],
-  "getSpaces": [Function],
+  "fetchSpacesEncrypted": [Function],
   "initialState": Immutable.Map {
     "byId": Immutable.Map {},
   },

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
@@ -1,6 +1,5 @@
 import {storeUsers} from '@ciscospark/redux-module-users';
 import {storeActivities} from '@ciscospark/redux-module-activities';
-import {uniqBy} from 'lodash';
 
 import {
   TAG_LOCKED,
@@ -17,6 +16,16 @@ export const REMOVE_SPACE = 'spaces/REMOVE_SPACE';
 export const STORE_SPACE = 'spaces/STORE_SPACE';
 export const STORE_INITIAL_SPACE = 'spaces/STORE_INITIAL_SPACE';
 
+// The options to pass to convo service when fetching multiple spaces (for recents)
+const spacesConversationOptions = {
+  uuidEntryFormat: true,
+  personRefresh: true,
+  isActive: true,
+  lastViewableActivityOnly: false,
+  participantAckFilter: 'all',
+  participantsLimit: -1,
+  activitiesLimit: 0
+};
 
 /**
  * Updates the last seen date of a space
@@ -108,78 +117,6 @@ function decryptSpace(space) {
   return Promise.resolve(new Error('Space cannot be decrypted'));
 }
 
-
-/**
- * Fetches a list of spaces with options
- *
- * @export
- * @param {Object} sparkInstance
- * @param {Object} options
- * @returns {Function} thunk
- */
-export function getSpaces(sparkInstance, options = {}) {
-  const listOptions = Object.assign({
-    uuidEntryFormat: true,
-    personRefresh: true,
-    isActive: true,
-    lastViewableActivityOnly: true,
-    participantAckFilter: 'all',
-    deferDecrypt: false,
-    allFavorite: true,
-    participantsLimit: -1
-  }, options);
-  const {deferDecrypt} = options;
-
-  return (dispatch) => sparkInstance.internal.conversation
-    .list(listOptions)
-    .then((items) => {
-      const users = [];
-      const activities = [];
-
-      const spaces = items.map((space) => {
-        let decryptPromise;
-
-        // Start decryption
-        if (deferDecrypt && space.decrypt) {
-          decryptPromise = decryptSpace(space)
-            .then((decryptedSpace) => {
-              if (decryptedSpace) {
-                const s = Object.assign({}, decryptedSpace, {isDecrypting: false});
-                const decryptedActivities = decryptedSpace.activities.items;
-                const participants = decryptedSpace.participants.items;
-                const activityActors = activities.map((a) => a.actor);
-
-                dispatch(storeUsers([...participants, ...activityActors]));
-                dispatch(storeActivities(decryptedActivities));
-                dispatch(storeSpaces([s]));
-
-                return Promise.resolve(constructSpace(s));
-              }
-
-              return Promise.resolve(new Error('Space was not decrypted correctly'));
-            });
-        }
-        else {
-          // Since we are not decrypting, save the redux store and do one big push
-          users.push(...space.participants.items);
-          activities.push(...space.activities.items);
-        }
-
-        return Object.assign({}, space, {isDecrypting: deferDecrypt, decryptPromise});
-      });
-
-      const uniqueUsers = uniqBy(users, 'id');
-      const uniqueActivities = uniqBy(activities, 'id');
-
-      dispatch(storeUsers(uniqueUsers));
-      dispatch(storeActivities(uniqueActivities));
-      dispatch(storeSpaces(spaces));
-
-      return Promise.resolve(spaces);
-    });
-}
-
-
 /**
  * Updates the target space with incoming Mercury activity
  *
@@ -213,24 +150,6 @@ export function updateSpaceWithActivity(activity, isSelf, isReadable = false) {
   };
 }
 
-
-/**
- * Fetches a list of recent spaces for the authenticated sparkInstance
- *
- * @export
- * @param {Object} sparkInstance
- * @param {Object} options to pass to SDK
- * @returns {Function} thunk
- */
-export function fetchSpaces(sparkInstance, options = {}) {
-  return (dispatch) =>
-    dispatch(getSpaces(sparkInstance, {
-      conversationsLimit: options.limit || 15,
-      deferDecrypt: options.deferDecrypt || false
-    }));
-}
-
-
 /**
  * Fetches single space from server
  *
@@ -255,7 +174,68 @@ export function fetchSpace(sparkInstance, spaceId) {
       dispatch(storeActivities(space.activities.items));
       dispatch(storeSpaces([space]));
 
-      return Promise.resolve(space);
+      return Promise.resolve(constructSpace(space));
     });
   };
+}
+
+/**
+ * Fetches spaces encrypted, stores encrypted spaces, then decrypts them.
+ * This provides a better first time UX due to the fact that users can
+ * see the decryption progress of each space.
+ *
+ * @export
+ * @param {object} sparkInstance
+ * @param {object} [options={}]
+ * @returns {function} thunk
+ */
+export function fetchSpacesEncrypted(sparkInstance, options = {}) {
+  const listOptions = Object.assign({deferDecrypt: true}, spacesConversationOptions, options);
+
+  return (dispatch) => sparkInstance.internal.conversation
+    .list(listOptions)
+    .then((items) => {
+      const spaces = items.map((space) => {
+        const decryptPromise = decryptSpace(space)
+          .then((decryptedSpace) => {
+            if (decryptedSpace) {
+              const s = Object.assign({}, decryptedSpace, {isDecrypting: false});
+
+              dispatch(storeSpaces([s]));
+
+              return Promise.resolve(constructSpace(s));
+            }
+
+            return Promise.resolve(new Error('Space was not decrypted correctly'));
+          });
+
+        return Object.assign({}, space, {isDecrypting: true, decryptPromise});
+      });
+
+      dispatch(storeSpaces(spaces));
+
+      return Promise.resolve(spaces);
+    });
+}
+
+/**
+ * Fetches a list of spaces with options
+ *
+ * @export
+ * @param {Object} sparkInstance
+ * @param {Object} options
+ * @returns {Function} thunk
+ */
+export function fetchSpaces(sparkInstance, options = {}) {
+  const listOptions = Object.assign({}, spacesConversationOptions, options);
+
+  return (dispatch) => sparkInstance.internal.conversation
+    .list(listOptions)
+    .then((spaces) => {
+      dispatch(storeSpaces(spaces));
+
+      const constructedSpaces = spaces.map(constructSpace);
+
+      return Promise.resolve(constructedSpaces);
+    });
 }

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
@@ -171,16 +171,19 @@ describe('redux-module-space actions ', () => {
   describe('#fetchSpaces', () => {
     it('properly fetches spaces', () => {
       store.dispatch(actions.fetchSpaces(mockSpark)).then(() => {
-        expect(mockSpark.internal.conversation.list).toHaveBeenCalledTimes(2);
+        expect(mockSpark.internal.conversation.list).toHaveBeenCalled();
         expect(store.getActions()).toMatchSnapshot();
       });
     });
   });
 
-  describe('#getSpaces', () => {
-    it('properly gets spaces', () => {
-      store.dispatch(actions.getSpaces(mockSpark)).then(() => {
-        expect(mockSpark.internal.conversation.list).toHaveBeenCalledTimes(1);
+  describe('#fetchSpacesEncrypted', () => {
+    it('properly fetches encrypted spaces', () => {
+      store.dispatch(actions.fetchSpacesEncrypted(mockSpark)).then(() => {
+        expect(mockSpark.internal.conversation.list).toHaveBeenCalled();
+        const listCalls = mockSpark.internal.conversation.list.calls;
+
+        expect(listCalls[0][0].deferDecrypt).toBe(true);
         expect(store.getActions()).toMatchSnapshot();
       });
     });

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/helpers.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/helpers.js
@@ -37,7 +37,7 @@ export function constructSpace(space) {
     lastReadableActivityDate: space.lastReadableActivityDate,
     lastSeenActivityDate: space.lastSeenActivityDate,
     conversationWebUrl: space.conversationWebUrl,
-    participants: space.participants.items.map((p) => p.id),
+    participants: space.participants.items,
     type: space.tags.includes(TAG_ONE_ON_ONE) ? SPACE_TYPE_ONE_ON_ONE : SPACE_TYPE_GROUP,
     published: space.published,
     tags: space.tags,

--- a/packages/node_modules/@ciscospark/widget-message/src/helpers.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/helpers.js
@@ -18,7 +18,7 @@ import {
  */
 export function handleConversationActivityEvent(event, eventNames, currentUserId, space, actions) {
   const {activity} = event.data;
-  const toUser = space.toPerson;
+  const toUser = space.toUser && space.toUser.toJS();
   const isSelf = activity.actor.id === currentUserId;
 
   // Ignore activity from other conversations

--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/listeners.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/listeners.js
@@ -7,6 +7,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
 import {storeActivities} from '@ciscospark/redux-module-activities';
+import {fetchAvatar} from '@ciscospark/redux-module-avatar';
 import {
   addSpaceTags,
   fetchSpace,
@@ -15,7 +16,8 @@ import {
   updateSpaceWithActivity,
   updateSpaceRead
 } from '@ciscospark/redux-module-spaces';
-import {API_ACTIVITY_VERB} from '@ciscospark/react-component-utils';
+import {storeUser} from '@ciscospark/redux-module-users';
+import {API_ACTIVITY_VERB, SPACE_TYPE_ONE_ON_ONE} from '@ciscospark/react-component-utils';
 
 import {
   eventNames,
@@ -25,6 +27,7 @@ import {
 } from '../events';
 
 import {updateWidgetStatus} from '../actions';
+import {getToParticipant, getSpaceAvatar} from '../helpers';
 import getRecentsWidgetProps from '../selector';
 
 /**
@@ -74,9 +77,10 @@ function processActivity(activity, space, props) {
   switch (activity.verb) {
     case API_ACTIVITY_VERB.SHARE:
     case API_ACTIVITY_VERB.POST: {
-      const otherUserId = !!space.participants && typeof space.participants.find === 'function' && space.participants
+      const otherParticipant = !!space.participants && typeof space.participants.find === 'function' && space.participants
         .find((p) => p.id !== currentUserId);
-      const otherUser = users.getIn(['byId', otherUserId]);
+      const otherParticipantId = otherParticipant && otherParticipant.id;
+      const otherUser = users.getIn(['byId', otherParticipantId]);
 
       // Update space with newest post activity
       props.updateSpaceWithActivity(activity, isSelf, true);
@@ -149,7 +153,8 @@ function processActivity(activity, space, props) {
 function handleNewActivity(activity, props) {
   const {
     sparkInstance,
-    spacesById
+    spacesById,
+    users
   } = props;
 
   let spaceId = activity.target && activity.target.id;
@@ -175,6 +180,16 @@ function handleNewActivity(activity, props) {
       .then((newSpace) => {
         if (newSpace) {
           processActivity(activity, newSpace, props);
+          getSpaceAvatar(newSpace, props);
+
+          // Store user for 1:1 spaces
+          if (newSpace.type === SPACE_TYPE_ONE_ON_ONE) {
+            const toUser = getToParticipant(newSpace, users.get('currentUserId'));
+
+            if (toUser) {
+              props.storeUser(toUser);
+            }
+          }
         }
       });
   }
@@ -185,10 +200,12 @@ export default compose(
     getRecentsWidgetProps,
     (dispatch) => bindActionCreators({
       addSpaceTags,
+      fetchAvatar,
       fetchSpace,
       removeSpace,
       removeSpaceTags,
       storeActivities,
+      storeUser,
       updateSpaceRead,
       updateSpaceWithActivity,
       updateWidgetStatus

--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
@@ -5,42 +5,39 @@ import {bindActionCreators} from 'redux';
 import {fetchAvatar} from '@ciscospark/redux-module-avatar';
 import {getFeature} from '@ciscospark/redux-module-features';
 import {connectToMercury} from '@ciscospark/redux-module-mercury';
-import {fetchSpaces} from '@ciscospark/redux-module-spaces';
+import {fetchSpaces, fetchSpacesEncrypted} from '@ciscospark/redux-module-spaces';
 import {fetchTeams} from '@ciscospark/redux-module-teams';
+import {storeUser} from '@ciscospark/redux-module-users';
 import {
   FEATURES_GROUP_MESSAGE_NOTIFICATIONS,
   FEATURES_MENTION_NOTIFICATIONS,
-  FEATURES_USER
+  FEATURES_USER,
+  SPACE_TYPE_ONE_ON_ONE
 } from '@ciscospark/react-component-utils';
 
 import {updateWidgetStatus} from '../actions';
+import {getToParticipant, getSpaceAvatar} from '../helpers';
 import getRecentsWidgetProps from '../selector';
 
 /**
- * Gets the avatar for a space
- * Will fetch the user avatar for 1:1 spaces
+ * Store the "to" participant in a 1:1 convo
+ * This user is needed in our store to calculate a space title
  *
- * @export
- * @param {Object} space
- * @param {Object} props
+ * @param {object} space
+ * @param {object} props
  */
-export function getSpaceAvatar(space, props) {
-  const {users, sparkInstance} = props;
+function storeToParticipant(space, props) {
+  const {users} = props;
 
-  if (!space.isDecrypting) {
-    if (
-      space.type === 'direct'
-    ) {
-      // Find the participant that is not the current user
-      const toPersonId = space.participants.find((p) => p !== users.get('currentUserId'));
+  // Store the to user in a direct convo to calculate space title
+  if (
+    space.type === SPACE_TYPE_ONE_ON_ONE
+  ) {
+    // Find the participant that is not the current user
+    const toPerson = getToParticipant(space, users.get('currentUserId'));
 
-      // Direct spaces use the "other participant" as the space avatar
-      props.fetchAvatar({userId: toPersonId}, sparkInstance);
-    }
-    else if (
-      space.type === 'group' && space.id
-    ) {
-      props.fetchAvatar({space}, sparkInstance);
+    if (toPerson) {
+      props.storeUser(toPerson);
     }
   }
 }
@@ -64,6 +61,11 @@ function connectWebsocket(props) {
   }
 }
 
+/**
+ * Gets the user's feature flags
+ *
+ * @param {object} props
+ */
 function getFeatures(props) {
   const {
     sparkInstance,
@@ -89,6 +91,11 @@ function getFeatures(props) {
   }
 }
 
+/**
+ * Gets the user's teams
+ *
+ * @param {*} props
+ */
 function getTeams(props) {
   const {
     sparkInstance,
@@ -110,6 +117,13 @@ function getTeams(props) {
   }
 }
 
+/**
+ * Fetches an encrypted small batch of spaces
+ * This allows us to show the encrypted spaces in the spaces list
+ * and decrypt individually to give a good initial user experience.
+ *
+ * @param {object} props
+ */
 function getInitialSpaces(props) {
   const {
     sparkInstance,
@@ -119,20 +133,20 @@ function getInitialSpaces(props) {
   if (!widgetStatus.isFetchingInitialSpaces
     && !widgetStatus.hasFetchedInitialSpaces) {
     props.updateWidgetStatus({isFetchingInitialSpaces: true});
-    props.fetchSpaces(sparkInstance, {
-      limit: props.spaceLoadCount,
-      // We don't need activities for the recents widget
-      activitiesLimit: 0,
-      lastViewableActivityOnly: false,
-      // Defer decrypt allows us to show the encrypted spaces in the space list
-      // before decrypting. Giving a better UX
-      deferDecrypt: true
+    props.fetchSpacesEncrypted(sparkInstance, {
+      conversationsLimit: props.spaceLoadCount
     })
       .then((encryptedSpaces) => {
         // As the spaces decrypt, get the avatar for them
         const promises = encryptedSpaces.map((s) =>
-          s.decryptPromise.then((decryptedSpace) =>
-            getSpaceAvatar(decryptedSpace, props)));
+          s.decryptPromise.then((decryptedSpace) => {
+            // Store the to user in a direct convo to calculate space title
+            if (decryptedSpace.type === SPACE_TYPE_ONE_ON_ONE) {
+              storeToParticipant(decryptedSpace, props);
+            }
+
+            return getSpaceAvatar(decryptedSpace, props);
+          }));
 
         return Promise.all(promises);
       })
@@ -142,6 +156,12 @@ function getInitialSpaces(props) {
   }
 }
 
+/**
+ * Gets a large batch of spaces to add to the existing
+ * initially loaded spaces.
+ *
+ * @param {object} props
+ */
 function getAllSpaces(props) {
   const {
     sparkInstance,
@@ -152,10 +172,16 @@ function getAllSpaces(props) {
     && !widgetStatus.hasFetchedAllSpaces) {
     props.updateWidgetStatus({isFetchingAllSpaces: true});
     props.fetchSpaces(sparkInstance, {
-      limit: 250,
-      activitiesLimit: 0,
-      lastViewableActivityOnly: false
+      limit: 250
     })
+      .then((spaces) => {
+        spaces.forEach((space) => {
+          // Store the to user in a direct convo to calculate space title
+          if (space.type === SPACE_TYPE_ONE_ON_ONE) {
+            storeToParticipant(space, props);
+          }
+        });
+      })
       .then(() => {
         props.updateWidgetStatus({
           hasFetchedAllSpaces: true
@@ -164,6 +190,11 @@ function getAllSpaces(props) {
   }
 }
 
+/**
+ * Fetches the avatars for all the loaded spaces
+ *
+ * @param {object} props
+ */
 function getAvatars(props) {
   const {
     spacesList,
@@ -173,13 +204,20 @@ function getAvatars(props) {
   if (!widgetStatus.hasFetchedAvatars
     && !widgetStatus.isFetchingAvatars) {
     props.updateWidgetStatus({isFetchingAvatars: true});
-    // TODO: Optimize loading order and pause between
+
     spacesList.forEach((s) => getSpaceAvatar(s, props));
 
     props.updateWidgetStatus({hasFetchedAvatars: true});
   }
 }
 
+/**
+ * The main setup process that proceeds through a series of events
+ * based on the state of the application.
+ *
+ * @export
+ * @param {*} props
+ */
 export function setup(props) {
   const {
     mercuryStatus,
@@ -228,8 +266,10 @@ export default compose(
       connectToMercury,
       fetchAvatar,
       fetchSpaces,
+      fetchSpacesEncrypted,
       fetchTeams,
       getFeature,
+      storeUser,
       updateWidgetStatus
     }, dispatch)
   ),

--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.test.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.test.js
@@ -1,4 +1,4 @@
-import {getSpaceAvatar, setup} from './setup';
+import {setup} from './setup';
 
 describe('widget-recents: enhancers: setup', () => {
   let props;
@@ -48,6 +48,7 @@ describe('widget-recents: enhancers: setup', () => {
       connectToMercury: jest.fn(),
       fetchAvatar: jest.fn(),
       fetchSpaces: jest.fn(() => Promise.resolve()),
+      fetchSpacesEncrypted: jest.fn(() => Promise.resolve()),
       getFeature: jest.fn(() => Promise.resolve()),
       updateWidgetStatus: jest.fn()
     };
@@ -114,36 +115,30 @@ describe('widget-recents: enhancers: setup', () => {
       it('should get initial spaces', () => {
         setup(props);
 
-        expect(props.fetchSpaces).toHaveBeenCalled();
-        const fetchConfig = props.fetchSpaces.mock.calls[0][1];
-
-        // Only the initial calls have deferDecrypt. Otherwise it is the all call
-        expect(fetchConfig.deferDecrypt).toBeDefined();
+        expect(props.fetchSpacesEncrypted).toHaveBeenCalled();
       });
 
       it('should not get initial spaces again during initial space load', () => {
         props.widgetStatus.isFetchingInitialSpaces = true;
         setup(props);
 
-        expect(props.fetchSpaces).not.toHaveBeenCalled();
+        expect(props.fetchSpacesEncrypted).not.toHaveBeenCalled();
       });
 
       it('should not get initial spaces again after initial space load', () => {
         props.widgetStatus.hasFetchedInitialSpaces = true;
         setup(props);
-        const fetchConfig = props.fetchSpaces.mock.calls[0][1];
 
-        // Only the initial calls have deferDecrypt. Otherwise it is the all call
-        expect(fetchConfig.deferDecrypt).not.toBeDefined();
+        expect(props.fetchSpacesEncrypted).not.toHaveBeenCalled();
       });
 
       it('should load the amount based on spaceLoadCount', () => {
         props.spaceLoadCount = 10;
 
         setup(props);
-        const fetchConfig = props.fetchSpaces.mock.calls[0][1];
+        const fetchConfig = props.fetchSpacesEncrypted.mock.calls[0][1];
 
-        expect(fetchConfig.limit).toBe(10);
+        expect(fetchConfig.conversationsLimit).toBe(10);
       });
     });
 
@@ -258,47 +253,6 @@ describe('widget-recents: enhancers: setup', () => {
           expect(props.fetchSpaces).not.toHaveBeenCalled();
         });
       });
-    });
-  });
-
-  describe('#getSpaceAvatar', () => {
-    it('should not fetch avatars for a decrypting space', () => {
-      const space = {
-        isDecrypting: true
-      };
-
-      getSpaceAvatar(space, props);
-
-      expect(props.fetchAvatar).not.toHaveBeenCalled();
-    });
-
-    it('should fetch the avatar for the group space id', () => {
-      const space = {
-        id: 'my-group-id',
-        isDecrypting: false,
-        type: 'group'
-      };
-
-      getSpaceAvatar(space, props);
-      const fetchConfig = props.fetchAvatar.mock.calls[0][0];
-
-      expect(fetchConfig.space.id).toEqual('my-group-id');
-    });
-
-    it('should fetch the avatar for the to person id', () => {
-      const space = {
-        isDecrypting: false,
-        participants: [
-          'my-user-id',
-          'to-user-id'
-        ],
-        type: 'direct'
-      };
-
-      getSpaceAvatar(space, props);
-      const fetchConfig = props.fetchAvatar.mock.calls[0][0];
-
-      expect(fetchConfig.userId).toEqual('to-user-id');
     });
   });
 });

--- a/packages/node_modules/@ciscospark/widget-recents/src/helpers.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/helpers.js
@@ -1,0 +1,46 @@
+import {SPACE_TYPE_GROUP, SPACE_TYPE_ONE_ON_ONE} from '@ciscospark/react-component-utils';
+
+/**
+ * Finds the participant in a direct space that isn't current user
+ *
+ * @param {object} space
+ * @param {string} currentUserId
+ * @returns {object} participant object
+ */
+export function getToParticipant(space, currentUserId) {
+  return space.participants.find((p) => p.id !== currentUserId);
+}
+
+/**
+ * Gets the avatar for a space
+ * Will fetch the user avatar for 1:1 spaces
+ *
+ * @export
+ * @param {Object} space
+ * @param {Object} props
+ * @param {function} props.fetchAvatar redux action
+ * @param {object} props.sparkInstance spark sdk instance
+ * @param {object} props.users users redux store
+ */
+export function getSpaceAvatar(space, props) {
+  const {users, sparkInstance} = props;
+
+  if (!space.isDecrypting) {
+    if (
+      space.type === SPACE_TYPE_ONE_ON_ONE
+    ) {
+      // Find the participant that is not the current user
+      const toParticipant = getToParticipant(space, users.get('currentUserId'));
+
+      if (toParticipant) {
+        // Direct spaces use the "other participant" as the space avatar
+        props.fetchAvatar({userId: toParticipant.id}, sparkInstance);
+      }
+    }
+    else if (
+      space.type === SPACE_TYPE_GROUP && space.id
+    ) {
+      props.fetchAvatar({space}, sparkInstance);
+    }
+  }
+}

--- a/packages/node_modules/@ciscospark/widget-recents/src/helpers.test.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/helpers.test.js
@@ -1,0 +1,89 @@
+import {SPACE_TYPE_GROUP, SPACE_TYPE_ONE_ON_ONE} from '@ciscospark/react-component-utils';
+
+import {getSpaceAvatar, getToParticipant} from './helpers';
+
+describe('widget-recents helpers file', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      sparkInstance: {
+        internal: {
+          device: {
+            registered: false
+          }
+        }
+      },
+      users: {
+        get: () => 'my-user-id'
+      },
+      fetchAvatar: jest.fn()
+    };
+  });
+
+  describe('#getSpaceAvatar', () => {
+    it('should not fetch avatars for a decrypting space', () => {
+      const space = {
+        isDecrypting: true
+      };
+
+      getSpaceAvatar(space, props);
+
+      expect(props.fetchAvatar).not.toHaveBeenCalled();
+    });
+
+    it('should fetch the avatar for the group space id', () => {
+      const space = {
+        id: 'my-group-id',
+        isDecrypting: false,
+        type: SPACE_TYPE_GROUP
+      };
+
+      getSpaceAvatar(space, props);
+      const fetchConfig = props.fetchAvatar.mock.calls[0][0];
+
+      expect(fetchConfig.space.id).toEqual('my-group-id');
+    });
+
+    it('should fetch the avatar for the to person id', () => {
+      const space = {
+        isDecrypting: false,
+        participants: [
+          {id: 'my-user-id'},
+          {id: 'to-user-id'}
+        ],
+        type: SPACE_TYPE_ONE_ON_ONE
+      };
+
+      getSpaceAvatar(space, props);
+      const fetchConfig = props.fetchAvatar.mock.calls[0][0];
+
+      expect(fetchConfig.userId).toEqual('to-user-id');
+    });
+  });
+
+  describe('#getToParticipant', () => {
+    it('should find the user that is not the current user', () => {
+      const space = {
+        participants: [
+          {id: 'myuserid'},
+          {id: 'touserid'}
+        ]
+      };
+      const toParticipant = getToParticipant(space, 'myuserid');
+
+      expect(toParticipant.id).toEqual('touserid');
+    });
+
+    it('should return undefined if no user found', () => {
+      const space = {
+        participants: [
+          {id: 'myuserid'}
+        ]
+      };
+      const toParticipant = getToParticipant(space, 'myuserid');
+
+      expect(toParticipant).not.toBeDefined();
+    });
+  });
+});

--- a/packages/node_modules/@ciscospark/widget-recents/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/selector.js
@@ -11,6 +11,8 @@ import {
   SPACE_TYPE_GROUP
 } from '@ciscospark/react-component-utils';
 
+import {getToParticipant} from './helpers';
+
 const getWidget = (state) => state.widgetRecents;
 const getSpark = (state) => state.spark;
 const getCurrentUser = (state, ownProps) => ownProps.currentUser;
@@ -60,8 +62,16 @@ function constructOneOnOne({space, currentUser, users}) {
   const thisSpace = constructSpace(space);
 
   // Get the user ID of the participant that isn't current user
-  const toPersonId = space.participants.find((p) => p !== currentUser.id);
-  const toPerson = users.get(toPersonId);
+  let toPerson, toPersonId;
+
+  const toParticipant = getToParticipant(space, currentUser.id);
+
+  // Sometimes we have a direct convo with only one participant
+  // (user has been deleted, etc)
+  if (toParticipant) {
+    toPersonId = toParticipant.id;
+    toPerson = users.get(toPersonId);
+  }
 
   if (toPerson) {
     thisSpace.toPersonId = toPersonId;


### PR DESCRIPTION
When fetching a group of spaces, we only need to store the user data from the "to user" in a one-on-one conversation. The recents widget does not need any other data in the redux store, ie: other participants and space activities. 

I've also split out `fetchSpacesEncrypted` from `fetchSpaces` to make things more readable.