### PR TITLE
feat(widgets):Semi-customized the scrollbar styling on IE11

### DIFF
--- a/packages/node_modules/@ciscospark/spark-widget-base/src/styles.css
+++ b/packages/node_modules/@ciscospark/spark-widget-base/src/styles.css
@@ -35,7 +35,7 @@ div::-webkit-scrollbar {
 ::-webkit-scrollbar-thumb {
   height: 50px;
   background-color: transparent;
-  border: none;
+  border-radius: 15px;
   box-shadow: none;
   background-clip: padding-box;
   border-image-source: initial initial initial;
@@ -44,7 +44,7 @@ div::-webkit-scrollbar {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: #8a8a8a;
 }
 
 ::-webkit-scrollbar-track {

--- a/packages/node_modules/@ciscospark/widget-recents/src/styles.css
+++ b/packages/node_modules/@ciscospark/widget-recents/src/styles.css
@@ -3,6 +3,12 @@
   height: 100%;
   flex-direction: column;
   font-family: CiscoSans, 'Helvetica Neue', Arial, sans-serif;
+
+  /* IE 11 scrollbar styling workarounds */
+  scrollbar-face-color: #8a8a8a;
+  scrollbar-shadow-color:black;
+  scrollbar-track-color: black;
+  scrollbar-shadow-color: black;
 }
 
 .spacesListWrapper {

--- a/packages/node_modules/@ciscospark/widget-space/src/styles.css
+++ b/packages/node_modules/@ciscospark/widget-space/src/styles.css
@@ -10,6 +10,13 @@
   box-sizing: border-box;
   flex-direction: column;
   flex: 1 1 auto;
+
+
+  /* IE 11 scrollbar styling workarounds */
+  scrollbar-face-color: #E0E0E0;
+  scrollbar-arrow-color: #E0E0E0;
+  scrollbar-shadow-color: white;
+  scrollbar-track-color: white;
 }
 
 .activityComponentWrapper {


### PR DESCRIPTION
Okay I need you guys to bear with me:

It's not possible to fully customize the scrollbars in IE11. there are some **non-standard** properties offered by MS that allows developers to only customize certain properties (mostly color related props). Unfortunately, we can not set the width of the scrollbar in IE11 using CSS (it could be done with other tools such as jQuery). I need your feedback for at least on space widget if you want it **with** or **without** arrows or what colors). I will share what  we had before and what we have changed them into:

## OLD - (Notice the scrollbar on the right)
![Screen Shot 2019-03-21 at 5 12 04 PM](https://user-images.githubusercontent.com/14226615/54793038-de4e6700-4bfd-11e9-876b-d0d34df951d1.png)

## NEW - (The scrollbar is there but it's black)
![Screen Shot 2019-03-21 at 5 13 48 PM](https://user-images.githubusercontent.com/14226615/54793054-f1613700-4bfd-11e9-978b-12295a596e9f.png)

## OLD - SPACE WIDGET
![Screen Shot 2019-03-21 at 5 11 45 PM](https://user-images.githubusercontent.com/14226615/54793089-135ab980-4bfe-11e9-8a70-0dc36b333e12.png)

## NEW - WITH ARROWS
![Screen Shot 2019-03-21 at 5 11 06 PM](https://user-images.githubusercontent.com/14226615/54793100-22416c00-4bfe-11e9-97cf-eb2b2032dba2.png)

## NEW - WITHOUT ARROWS
![Screen Shot 2019-03-21 at 5 12 44 PM](https://user-images.githubusercontent.com/14226615/54793122-32f1e200-4bfe-11e9-85b2-bd1344399303.png)


