### PR TITLE
chore(tab): don't install nvm on tab tests

### DIFF
--- a/Jenkinsfile.tab
+++ b/Jenkinsfile.tab
@@ -22,19 +22,15 @@ pipeline {
         withCredentials([
           string(credentialsId: 'WIDGETS_NPM_TOKEN', variable: 'WIDGETS_NPM_TOKEN')
         ]) {
+          sh 'echo \'//registry.npmjs.org/:_authToken=${WIDGETS_NPM_TOKEN}\' >> .npmrc'
           sh '''#!/bin/bash -e
-            set +x
-            rm .nvmrc
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
-            ~/.nvm/nvm.sh
-            sh 'echo \'//registry.npmjs.org/:_authToken=${WIDGETS_NPM_TOKEN}\' >> .npmrc'
-            source ~/.bashrc || true
-            source ~/.profile || true
-            nvm install v8.15.0
-            nvm use v8.15.0
-            npm install -g npm@6.4.1
-            npm ci
-            rm .npmrc
+          source ~/.nvm/nvm.sh
+          nvm install v8.15.0
+          nvm use v8.15.0
+          npm install -g npm@6.4.1
+          rm -rf node_modules/
+          npm install
+          git checkout .npmrc
           '''
         }
       }


### PR DESCRIPTION
TAB tests are failing due to the old nvm install command.