### PR TITLE
 fix(widget-recents): recents widget does not load for user with no spaces

### DIFF
--- a/packages/node_modules/@ciscospark/widget-recents/src/components/NoSpaces.css
+++ b/packages/node_modules/@ciscospark/widget-recents/src/components/NoSpaces.css
@@ -1,0 +1,29 @@
+.noSpacesWrapper {
+  height: 100%;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  background-color: black;
+}
+
+.noSpacesImg {
+  height: 72px;
+  width: 100%;
+  margin-bottom: 24px;
+}
+
+.noSpacesTitle {
+  color: #fff;
+  font-weight: 700;
+  line-height: 24px;
+  text-align: center;
+  margin-bottom: 12px;
+}
+
+.noSpacesMessage {
+  color: hsla(0,0%,100%,.6);
+  line-height: 22px;
+  text-align: center;
+}

--- a/packages/node_modules/@ciscospark/widget-recents/src/components/NoSpaces.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/components/NoSpaces.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import styles from './NoSpaces.css';
+
+const propTypes = {
+  title: PropTypes.string.isRequired,
+  emptyMessage: PropTypes.string.isRequired
+};
+
+function NoSpaces(props) {
+  const {
+    title,
+    emptyMessage
+  } = props;
+
+  return (
+    <div className={classNames('ciscospark-recents-widget-no-spaces', styles.noSpacesWrapper)}>
+      <div className={classNames('ciscospark-no-spaces-img', styles.noSpacesImg)}>
+        <svg width="80px" height="62px" viewBox="0 0 80 62" version="1.1" xmlns="http://www.w3.org/2000/svg">
+          <defs />
+          <g id="Illustrations" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+            <g id="Artboard" transform="translate(-1053.000000, -175.000000)" fill="#FFFFFF">
+              <g id="No-Space" transform="translate(1053.000000, 175.000000)">
+                <path d="M56.999,0 C44.297,0 34,10.297 34,22.999 C34,26.583 34.82,29.975 36.282,32.998 L37.822,32.998 L56.5,32.998 C56.775,32.998 57,33.223 57,33.498 C57,33.773 56.775,33.998 56.5,33.998 L38.353,33.998 L36.797,33.998 C40.697,41.147 48.281,45.998 56.999,45.998 C69.701,45.998 79.998,35.701 79.998,22.999 C79.998,10.297 69.701,0 56.999,0" id="fill" opacity="0.400000006" />
+                <path d="M29,33 L29,5.5 C29,5.225 28.775,5 28.5,5 C28.225,5 28,5.225 28,5.5 L28,33 L0.5,33 C0.225,33 0,33.225 0,33.5 C0,33.775 0.225,34 0.5,34 L28,34 L28,61.5 C28,61.775 28.225,62 28.5,62 C28.775,62 29,61.775 29,61.5 L29,34 L36.797,34 C36.617,33.671 36.445,33.338 36.282,33 L29,33 Z" id="fill" />
+              </g>
+            </g>
+          </g>
+        </svg>
+      </div>
+      <h2 className={classNames('ciscospark-no-spaces-title', styles.noSpacesTitle)}>{title}</h2>
+      <div className={classNames('ciscospark-no-spaces-message', styles.noSpacesMessage)}>{emptyMessage}</div>
+    </div>
+  );
+}
+
+NoSpaces.propTypes = propTypes;
+
+export default NoSpaces;

--- a/packages/node_modules/@ciscospark/widget-recents/src/components/NoSpaces.test.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/components/NoSpaces.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+import NoSpaces from './NoSpaces';
+
+const renderer = new ShallowRenderer();
+
+let props, component;
+
+describe('NoSpaces component', () => {
+  beforeEach(() => {
+    props = {
+      title: 'No Spaces Title',
+      emptyMessage: 'No spaces message.'
+    };
+  });
+
+  it('renders correctly', () => {
+    renderer.render(
+      <NoSpaces {...props} />
+    );
+
+    component = renderer.getRenderOutput();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/packages/node_modules/@ciscospark/widget-recents/src/components/__snapshots__/NoSpaces.test.js.snap
+++ b/packages/node_modules/@ciscospark/widget-recents/src/components/__snapshots__/NoSpaces.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoSpaces component renders correctly 1`] = `
+<div
+  className="ciscospark-recents-widget-no-spaces noSpacesWrapper"
+>
+  <div
+    className="ciscospark-no-spaces-img noSpacesImg"
+  >
+    <svg
+      height="62px"
+      version="1.1"
+      viewBox="0 0 80 62"
+      width="80px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs />
+      <g
+        fill="none"
+        fillRule="evenodd"
+        id="Illustrations"
+        stroke="none"
+        strokeWidth="1"
+      >
+        <g
+          fill="#FFFFFF"
+          id="Artboard"
+          transform="translate(-1053.000000, -175.000000)"
+        >
+          <g
+            id="No-Space"
+            transform="translate(1053.000000, 175.000000)"
+          >
+            <path
+              d="M56.999,0 C44.297,0 34,10.297 34,22.999 C34,26.583 34.82,29.975 36.282,32.998 L37.822,32.998 L56.5,32.998 C56.775,32.998 57,33.223 57,33.498 C57,33.773 56.775,33.998 56.5,33.998 L38.353,33.998 L36.797,33.998 C40.697,41.147 48.281,45.998 56.999,45.998 C69.701,45.998 79.998,35.701 79.998,22.999 C79.998,10.297 69.701,0 56.999,0"
+              id="fill"
+              opacity="0.400000006"
+            />
+            <path
+              d="M29,33 L29,5.5 C29,5.225 28.775,5 28.5,5 C28.225,5 28,5.225 28,5.5 L28,33 L0.5,33 C0.225,33 0,33.225 0,33.5 C0,33.775 0.225,34 0.5,34 L28,34 L28,61.5 C28,61.775 28.225,62 28.5,62 C28.775,62 29,61.775 29,61.5 L29,34 L36.797,34 C36.617,33.671 36.445,33.338 36.282,33 L29,33 Z"
+              id="fill"
+            />
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+  <h2
+    className="ciscospark-no-spaces-title noSpacesTitle"
+  >
+    No Spaces Title
+  </h2>
+  <div
+    className="ciscospark-no-spaces-message noSpacesMessage"
+  >
+    No spaces message.
+  </div>
+</div>
+`;

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -21,6 +21,9 @@ import LoadingScreen from '@webex/react-component-loading-screen';
 import ErrorDisplay from '@ciscospark/react-component-error-display';
 import SpacesList from '@webex/react-component-spaces-list';
 
+import messages from './messages';
+
+import NoSpaces from './components/NoSpaces';
 import RecentsHeader from './components/RecentsHeader';
 
 import enhancers from './enhancers';
@@ -237,13 +240,16 @@ export class RecentsWidget extends Component {
 
     // Recents widget is ready once we have some spaces or a search causing spaces to be empty
     const isFiltered = keywordFilter && keywordFilter.length;
-    const isReady = spacesListArray && (spacesListArray.length || isFiltered);
+    const isReady = (widgetStatus.hasFetchedInitialSpaces || isFiltered);
 
     const isLoadingMore = props.extendedLoad
       ? !widgetStatus.hasFetchedAllSpaces : !widgetStatus.hasFetchedInitialSpaces;
 
     // Display the header if any of these options are true, otherwise, hide header.
     const showHeader = enableSpaceListFilter || enableAddButton || enableUserProfile;
+    const hasSpaces = widgetStatus.hasFetchedInitialSpaces && spacesListArray.length > 0;
+    const emptyMessage = !hasSpaces && enableAddButton ? formatMessage(messages.createSpacePlus)
+      : formatMessage(messages.createSpaceTeams);
 
     if (errors.get('hasError')) {
       widgetError = errors.get('errors').first();
@@ -282,20 +288,30 @@ export class RecentsWidget extends Component {
               onSignOutClick={this.handleSignOutClick}
             />
           }
-          <div className={classNames('ciscospark-spaces-list-wrapper', styles.spacesListWrapper)}>
-            <SpacesList
-              currentUser={currentUser}
-              features={features}
-              formatMessage={formatMessage}
-              hasCalling
-              isLoadingMore={isLoadingMore}
-              onCallClick={this.handleSpaceCallClick}
-              onClick={this.handleSpaceClick}
-              onScroll={this.handleListScroll}
-              spaces={spacesListArray}
-              searchTerm={typeof keywordFilter === 'string' ? keywordFilter : ''}
+          {
+            hasSpaces &&
+            <div className={classNames('ciscospark-spaces-list-wrapper', styles.spacesListWrapper)}>
+              <SpacesList
+                currentUser={currentUser}
+                features={features}
+                formatMessage={formatMessage}
+                hasCalling
+                isLoadingMore={isLoadingMore}
+                onCallClick={this.handleSpaceCallClick}
+                onClick={this.handleSpaceClick}
+                onScroll={this.handleListScroll}
+                spaces={spacesListArray}
+                searchTerm={typeof keywordFilter === 'string' ? keywordFilter : ''}
+              />
+            </div>
+          }
+          {
+            !hasSpaces &&
+            <NoSpaces
+              title={formatMessage(messages.noSpaces)}
+              emptyMessage={emptyMessage}
             />
-          </div>
+          }
         </div>
       );
     }

--- a/packages/node_modules/@ciscospark/widget-recents/src/messages.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/messages.js
@@ -10,6 +10,18 @@ export default defineMessages({
     id: 'ciscospark.container.recents.sharedFile',
     defaultMessage: 'Shared a file'
   },
+  noSpaces: {
+    id: 'ciscospark.container.recents.noSpaces',
+    defaultMessage: 'No spaces yet'
+  },
+  createSpacePlus: {
+    id: 'ciscospark.container.recents.createSpacePlus',
+    defaultMessage: 'Create a space using the plus button next to the search bar above.'
+  },
+  createSpaceTeams: {
+    id: 'ciscospark.container.recents.createSpaceTeams',
+    defaultMessage: 'Create spaces in Webex Teams to see them here.'
+  },
   unavailable: {
     id: 'ciscospark.container.recents.userUnavailable',
     defaultMessage: '{actorName} was unavailable.'

--- a/test/journeys/lib/test-helpers/recents-widget/index.js
+++ b/test/journeys/lib/test-helpers/recents-widget/index.js
@@ -4,8 +4,10 @@ import waitForPromise from '../../wait-for-promise';
 
 export const elements = {
   loadingScreen: '.ciscospark-loading',
-  recentsWidget: '.ciscospark-spaces-list-wrapper',
+  recentsWidget: '.ciscospark-recents-widget',
   listContainer: '.ciscospark-spaces-list',
+  noSpacesTitle: '.ciscospark-no-spaces-title',
+  noSpacesMessage: '.ciscospark-no-spaces-message',
   firstSpace: '.ciscospark-spaces-list-item-0',
   title: '.cui-list-item__header',
   unreadIndicator: '.cui-list-item--unread',

--- a/test/journeys/specs/smoke/widget-recents/index.js
+++ b/test/journeys/specs/smoke/widget-recents/index.js
@@ -43,13 +43,11 @@ describe('Smoke Tests - Recents Widget', () => {
     browserRemote.url('/space.html?meetRecents');
   });
 
-  it('create test users and spaces', () => {
+  it('create test users', () => {
     participants = setupGroupTestUsers();
     assert.lengthOf(participants, 3, 'Test users were not created');
     [docbrown, lorraine, marty] = participants;
     registerDevices(participants);
-    conversation = createSpace({sparkInstance: marty.spark, participants, displayName: 'Test Group Space'});
-    oneOnOneConversation = createSpace({sparkInstance: marty.spark, participants: [lorraine, marty]});
   });
 
   it('open recents widget for marty', () => {
@@ -105,7 +103,24 @@ describe('Smoke Tests - Recents Widget', () => {
     });
   });
 
+  describe('No Spaces Message', () => {
+    it('has no spaces title', () => {
+      assert.isTrue(browserLocal.element(elements.noSpacesTitle).isVisible(), 'does not have no spaces title');
+      assert.equal(browserLocal.element(elements.noSpacesTitle).getText(), 'No spaces yet');
+    });
+
+    it('has no spaces message', () => {
+      assert.isTrue(browserLocal.element(elements.noSpacesMessage).isVisible(), 'does not have no spaces message');
+      assert.equal(browserLocal.element(elements.noSpacesMessage).getText(), 'Create a space using the plus button next to the search bar above.');
+    });
+  });
+
   describe('Group Space', () => {
+    it('creates spaces', () => {
+      conversation = createSpace({sparkInstance: marty.spark, participants, displayName: 'Test Group Space'});
+      oneOnOneConversation = createSpace({sparkInstance: marty.spark, participants: [lorraine, marty]});
+    });
+
     it('displays a new incoming message', () => {
       const lorraineText = 'Marty, will we ever see you again?';
 


### PR DESCRIPTION
Fix bug where recents widget would get stuck on the loading spinner for a user with no spaces + implement no spaces design.

The CSS is borrowed from the web client to make sure we're in line with their design -- if y'all want any changes just let me know.

There is currently no better way to handle the no spaces SVG as our usual icon component can only handle SVGs with one path, not two. Collab-ui doesn't currently have an icon for it, either.