### PR TITLE
fix(r-m-spaces): match web client convo options

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
@@ -18,12 +18,11 @@ export const STORE_INITIAL_SPACE = 'spaces/STORE_INITIAL_SPACE';
 
 // The options to pass to convo service when fetching multiple spaces (for recents)
 const spacesConversationOptions = {
-  uuidEntryFormat: true,
-  personRefresh: true,
+  ackFilter: 'noack',
   isActive: true,
   lastViewableActivityOnly: false,
   participantAckFilter: 'all',
-  participantsLimit: -1,
+  participantsLimit: 2,
   activitiesLimit: 0
 };
 


### PR DESCRIPTION
This is the magic config that gets a spaces list that more closely matches the clients.

Please check the netlify deploy and do a limited space load to verify that it matches your desktop client space list. I only had one space missing that was a meeting only space on the mac client.