### PR TITLE
feat(widget-recents): update scroll status as needed

### DIFF
--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -172,7 +172,9 @@ export class RecentsWidget extends Component {
   handleListScroll({scrollTop}) {
     const isScrolledToTop = scrollTop === 0;
 
-    this.props.updateWidgetStatus({isScrolledToTop});
+    if (isScrolledToTop !== this.props.widgetStatus.isScrolledToTop) {
+      this.props.updateWidgetStatus({isScrolledToTop});
+    }
   }
 
   @autobind


### PR DESCRIPTION
The previous code would fire events to redux with every mouse scroll.
This changes so that it only updates the store when the `isScrolledToTop` actually changes.