### PR TITLE
fix(widget-recents): load space avatars properly

### DIFF
--- a/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/enhancers/setup.js
@@ -150,12 +150,13 @@ function getInitialSpaces(props) {
       props.fetchSpacesEncrypted(sparkInstance, {
         conversationsLimit: props.spaceLoadCount
       })
-        .then(() => props.updateWidgetStatus({
-          hasFetchedInitialSpaces: true,
-          // Extended load false doesn't have a second load state
-          hasFetchedAllSpaces: !props.extendedLoad
-        }))
         .then((encryptedSpaces) => {
+          props.updateWidgetStatus({
+            hasFetchedInitialSpaces: true,
+            // Extended load false doesn't have a second load state
+            hasFetchedAllSpaces: !props.extendedLoad
+          });
+
           // As the spaces decrypt, get the avatar for them
           const promises = encryptedSpaces.map((s) =>
             s.decryptPromise.then((decryptedSpace) => {


### PR DESCRIPTION
Avatars and people were not being loaded properly because the `encryptedSpaces` object wasn't being passed properly.

One too many `.thens` in the code