### PR TITLE
chore(Jenkins): add gitcommit file to archives

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,6 +158,7 @@ ansiColor('xterm') {
               npm run release -- --release-as patch --no-verify
               version=`grep "version" package.json | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g'`
               echo $version > .version
+              git rev-parse HEAD > gitcommit
               '''
               packageJsonVersion = readFile '.version'
             }
@@ -207,6 +208,7 @@ ansiColor('xterm') {
             archive 'packages/node_modules/@ciscospark/widget-space-demo/dist/**/*'
             archive 'packages/node_modules/@ciscospark/widget-recents-demo/dist/**/*'
             archive 'packages/node_modules/@ciscospark/widget-demo/dist/**/*'
+            archive 'gitcommit'
 
 
             stage('Push to github'){


### PR DESCRIPTION
file "gitcommit" that gets archived with the build as well. When the production push job gets done, it will update the commit from the "gitcommit" file with the git tag "production". That way, the TAP tests can check out "production" before running.