### PR TITLE
chore(scripts): filter demo from get widget script

### DIFF
--- a/scripts/utils/package.js
+++ b/scripts/utils/package.js
@@ -162,7 +162,7 @@ function getWidgetPackages() {
     .filter((pkgPath) => {
       const pkgName = require(path.resolve(pkgPath, 'package.json')).name;
 
-      return pkgName.startsWith('@ciscospark/widget');
+      return pkgName.startsWith('@ciscospark/widget') && !pkgName.endsWith('-demo');
     });
 }
 


### PR DESCRIPTION
The build for es/npm is failing due to sass issues in the widget demo. Since widget demo isn't on npm, this is a short term fix to stop building the demo and other demos for npm.