### PR TITLE
chore(circleci): run journey tests serially to reduce timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,4 +161,4 @@ workflows:
             - build_for_tests
       - journey_tests_firefox:
           requires:
-            - build_for_tests
+            - journey_tests_chrome


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/190647/58590461-1d1e2000-8232-11e9-939d-6965aa2ee0ca.png)

There seems to be issues when circle runs the integration tests at the same time on different browsers. It could be purely coincidence, but this seems to have passed easier.